### PR TITLE
Add TierTree and ITier

### DIFF
--- a/org.eclipse.scout.sdk.core.s.test/src/test/java/org/eclipse/scout/sdk/core/s/util/ScoutTierTest.java
+++ b/org.eclipse.scout.sdk.core.s.test/src/test/java/org/eclipse/scout/sdk/core/s/util/ScoutTierTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.Test;
 public class ScoutTierTest {
 
   @Test
-  @SuppressWarnings("ConstantConditions")
   public void testFilter() {
     assertTrue(ScoutTier.Shared.isIncludedIn(ScoutTier.Client));
     assertTrue(ScoutTier.Shared.isIncludedIn(ScoutTier.Server));
@@ -105,23 +104,27 @@ public class ScoutTierTest {
     assertFalse(ScoutTier.Client.test(mock));
     assertFalse(ScoutTier.Server.test(mock));
     assertFalse(ScoutTier.HtmlUi.test(mock));
+    when(p.exists(scoutApi.ISession().fqn())).thenReturn(Boolean.FALSE);
 
     when(p.exists(scoutApi.IServerSession().fqn())).thenReturn(Boolean.TRUE);
     assertTrue(ScoutTier.Shared.test(mock));
     assertFalse(ScoutTier.Client.test(mock));
     assertTrue(ScoutTier.Server.test(mock));
     assertFalse(ScoutTier.HtmlUi.test(mock));
+    when(p.exists(scoutApi.IServerSession().fqn())).thenReturn(Boolean.FALSE);
 
     when(p.exists(scoutApi.IClientSession().fqn())).thenReturn(Boolean.TRUE);
     assertTrue(ScoutTier.Shared.test(mock));
     assertTrue(ScoutTier.Client.test(mock));
     assertFalse(ScoutTier.Server.test(mock));
     assertFalse(ScoutTier.HtmlUi.test(mock));
+    when(p.exists(scoutApi.IClientSession().fqn())).thenReturn(Boolean.FALSE);
 
     when(p.exists(scoutApi.UiServlet().fqn())).thenReturn(Boolean.TRUE);
     assertTrue(ScoutTier.Shared.test(mock));
     assertTrue(ScoutTier.Client.test(mock));
     assertFalse(ScoutTier.Server.test(mock));
     assertTrue(ScoutTier.HtmlUi.test(mock));
+    when(p.exists(scoutApi.UiServlet().fqn())).thenReturn(Boolean.FALSE);
   }
 }

--- a/org.eclipse.scout.sdk.core.s.test/src/test/java/org/eclipse/scout/sdk/core/s/util/TierTreeTest.java
+++ b/org.eclipse.scout.sdk.core.s.test/src/test/java/org/eclipse/scout/sdk/core/s/util/TierTreeTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.sdk.core.s.util;
+
+import static org.eclipse.scout.rt.platform.util.CollectionUtility.arrayList;
+import static org.eclipse.scout.rt.platform.util.CollectionUtility.lastElement;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.scout.sdk.core.s.apidef.IScoutApi;
+import org.eclipse.scout.sdk.core.s.testing.ScoutFixtureHelper.ScoutFullJavaEnvironmentFactory;
+import org.eclipse.scout.sdk.core.s.testing.ScoutFixtureHelper.ScoutSharedJavaEnvironmentFactory;
+import org.eclipse.scout.sdk.core.s.testing.context.ExtendWithTestingEnvironment;
+import org.eclipse.scout.sdk.core.s.testing.context.TestingEnvironment;
+import org.eclipse.scout.sdk.core.testing.context.ExtendWithJavaEnvironmentFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TierTreeTest {
+
+  private TierTree m_tierTree;
+
+  @BeforeEach
+  public void before() {
+    m_tierTree = TierTree.create();
+
+    // Level 1
+    m_tierTree.addDependencyImpl(TestTier.A1, TestTier.Root);
+    m_tierTree.addDependencyImpl(TestTier.B1, TestTier.Root);
+    m_tierTree.addDependencyImpl(TestTier.C1, TestTier.Root);
+
+    // Level 2
+    m_tierTree.addDependencyImpl(TestTier.A1_AA1, TestTier.A1);
+    m_tierTree.addDependencyImpl(TestTier.A1_AA2, TestTier.A1);
+    m_tierTree.addDependencyImpl(TestTier.A1_AA3, TestTier.A1);
+
+    m_tierTree.addDependencyImpl(TestTier.B1_BB1, TestTier.B1);
+    m_tierTree.addDependencyImpl(TestTier.B1_BB2, TestTier.B1);
+    m_tierTree.addDependencyImpl(TestTier.B1_BB3, TestTier.B1);
+
+    m_tierTree.addDependencyImpl(TestTier.C1_CC1, TestTier.C1);
+    m_tierTree.addDependencyImpl(TestTier.C1_CC2, TestTier.C1);
+    m_tierTree.addDependencyImpl(TestTier.C1_CC3, TestTier.C1);
+
+    // Level 3
+    m_tierTree.addDependencyImpl(TestTier.A1_AA1_AAA1, TestTier.A1_AA1);
+    m_tierTree.addDependencyImpl(TestTier.A1_AA1_AAA2, TestTier.A1_AA1);
+    m_tierTree.addDependencyImpl(TestTier.A1_AA1_AAA3, TestTier.A1_AA1);
+
+    m_tierTree.addDependencyImpl(TestTier.A1_AA2_AAA4, TestTier.A1_AA2);
+    m_tierTree.addDependencyImpl(TestTier.A1_AA2_AAA5, TestTier.A1_AA2);
+    m_tierTree.addDependencyImpl(TestTier.A1_AA2_AAA6, TestTier.A1_AA2);
+
+    m_tierTree.addDependencyImpl(TestTier.A1_AA3_AAA7, TestTier.A1_AA3);
+    m_tierTree.addDependencyImpl(TestTier.A1_AA3_AAA8, TestTier.A1_AA3);
+    m_tierTree.addDependencyImpl(TestTier.A1_AA3_AAA9, TestTier.A1_AA3);
+
+    m_tierTree.addDependencyImpl(TestTier.B1_BB1_BBB1, TestTier.B1_BB1);
+    m_tierTree.addDependencyImpl(TestTier.B1_BB1_BBB2, TestTier.B1_BB1);
+    m_tierTree.addDependencyImpl(TestTier.B1_BB1_BBB3, TestTier.B1_BB1);
+
+    m_tierTree.addDependencyImpl(TestTier.C1_CC1_CCC1, TestTier.C1_CC1);
+    m_tierTree.addDependencyImpl(TestTier.C1_CC1_CCC2, TestTier.C1_CC1);
+    m_tierTree.addDependencyImpl(TestTier.C1_CC1_CCC3, TestTier.C1_CC1);
+  }
+
+  @Test
+  public void testAddDependency() {
+    // Tree not empty and both are not already contained
+    assertFalse(m_tierTree.addDependencyImpl(AddDependencyTier.C1_CC2_CCC5, AddDependencyTier.C1_CC2_CCC4));
+
+    // Tree not empty and one is already contained
+    assertTrue(m_tierTree.addDependencyImpl(AddDependencyTier.C1_CC2_CCC4, TestTier.C1_CC2));
+    assertTrue(m_tierTree.addDependencyImpl(AddDependencyTier.C1_CC2_CCC5, TestTier.C1_CC2));
+    assertTrue(m_tierTree.addDependencyImpl(AddDependencyTier.C1_CC2_CCC6, TestTier.C1_CC2));
+
+    // Tree not empty and both are already contained
+    assertFalse(m_tierTree.addDependencyImpl(AddDependencyTier.C1_CC2_CCC5, TestTier.A1));
+  }
+
+  @Test
+  public void testHasDependency() {
+    assertFalse(m_tierTree.hasDependencyImpl(TestTier.A1, TestTier.A1));
+
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.A1_AA1, TestTier.A1));
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.A1_AA2, TestTier.A1));
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.A1_AA3, TestTier.A1));
+
+    assertFalse(m_tierTree.hasDependencyImpl(TestTier.A1_AA1, TestTier.A1_AA1));
+    assertFalse(m_tierTree.hasDependencyImpl(TestTier.A1_AA2, TestTier.A1_AA2));
+    assertFalse(m_tierTree.hasDependencyImpl(TestTier.A1_AA3, TestTier.A1_AA3));
+
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.A1_AA1_AAA1, TestTier.A1_AA1));
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.A1_AA1_AAA2, TestTier.A1_AA1));
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.A1_AA1_AAA3, TestTier.A1_AA1));
+
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.A1_AA2_AAA4, TestTier.A1_AA2));
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.A1_AA2_AAA5, TestTier.A1_AA2));
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.A1_AA2_AAA6, TestTier.A1_AA2));
+
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.A1_AA3_AAA7, TestTier.A1_AA3));
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.A1_AA3_AAA8, TestTier.A1_AA3));
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.A1_AA3_AAA9, TestTier.A1_AA3));
+
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.A1_AA1_AAA1, TestTier.A1));
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.A1_AA1_AAA2, TestTier.A1));
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.A1_AA1_AAA3, TestTier.A1));
+
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.A1_AA2_AAA4, TestTier.A1));
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.A1_AA2_AAA5, TestTier.A1));
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.A1_AA2_AAA6, TestTier.A1));
+
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.A1_AA3_AAA7, TestTier.A1));
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.A1_AA3_AAA8, TestTier.A1));
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.A1_AA3_AAA9, TestTier.A1));
+
+    assertFalse(m_tierTree.hasDependencyImpl(TestTier.B1_BB1, TestTier.A1));
+    assertFalse(m_tierTree.hasDependencyImpl(TestTier.B1_BB2, TestTier.A1));
+    assertFalse(m_tierTree.hasDependencyImpl(TestTier.B1_BB3, TestTier.A1));
+
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.B1_BB1, TestTier.B1));
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.B1_BB2, TestTier.B1));
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.B1_BB3, TestTier.B1));
+
+    assertFalse(m_tierTree.hasDependencyImpl(TestTier.B1_BB1_BBB1, TestTier.A1));
+    assertFalse(m_tierTree.hasDependencyImpl(TestTier.B1_BB1_BBB2, TestTier.A1));
+    assertFalse(m_tierTree.hasDependencyImpl(TestTier.B1_BB1_BBB3, TestTier.A1));
+
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.B1_BB1_BBB1, TestTier.B1));
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.B1_BB1_BBB2, TestTier.B1));
+    assertTrue(m_tierTree.hasDependencyImpl(TestTier.B1_BB1_BBB3, TestTier.B1));
+
+    assertFalse(m_tierTree.hasDependencyImpl(TestTier.B1_BB1_BBB1, TestTier.B1_BB1_BBB1));
+    assertFalse(m_tierTree.hasDependencyImpl(TestTier.B1_BB1_BBB2, TestTier.B1_BB1_BBB2));
+    assertFalse(m_tierTree.hasDependencyImpl(TestTier.B1_BB1_BBB3, TestTier.B1_BB1_BBB3));
+  }
+
+  @Test
+  public void testIsAvailable() {
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1, TestTier.A1));
+
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA1, TestTier.A1));
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA2, TestTier.A1));
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA3, TestTier.A1));
+
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA1, TestTier.A1_AA1));
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA2, TestTier.A1_AA2));
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA3, TestTier.A1_AA3));
+
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA1_AAA1, TestTier.A1_AA1));
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA1_AAA2, TestTier.A1_AA1));
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA1_AAA3, TestTier.A1_AA1));
+
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA2_AAA4, TestTier.A1_AA2));
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA2_AAA5, TestTier.A1_AA2));
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA2_AAA6, TestTier.A1_AA2));
+
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA3_AAA7, TestTier.A1_AA3));
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA3_AAA8, TestTier.A1_AA3));
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA3_AAA9, TestTier.A1_AA3));
+
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA1_AAA1, TestTier.A1));
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA1_AAA2, TestTier.A1));
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA1_AAA3, TestTier.A1));
+
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA2_AAA4, TestTier.A1));
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA2_AAA5, TestTier.A1));
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA2_AAA6, TestTier.A1));
+
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA3_AAA7, TestTier.A1));
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA3_AAA8, TestTier.A1));
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.A1_AA3_AAA9, TestTier.A1));
+
+    assertFalse(m_tierTree.isAvailableImpl(TestTier.B1_BB1, TestTier.A1));
+    assertFalse(m_tierTree.isAvailableImpl(TestTier.B1_BB2, TestTier.A1));
+    assertFalse(m_tierTree.isAvailableImpl(TestTier.B1_BB3, TestTier.A1));
+
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.B1_BB1, TestTier.B1));
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.B1_BB2, TestTier.B1));
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.B1_BB3, TestTier.B1));
+
+    assertFalse(m_tierTree.isAvailableImpl(TestTier.B1_BB1_BBB1, TestTier.A1));
+    assertFalse(m_tierTree.isAvailableImpl(TestTier.B1_BB1_BBB2, TestTier.A1));
+    assertFalse(m_tierTree.isAvailableImpl(TestTier.B1_BB1_BBB3, TestTier.A1));
+
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.B1_BB1_BBB1, TestTier.B1));
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.B1_BB1_BBB2, TestTier.B1));
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.B1_BB1_BBB3, TestTier.B1));
+
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.B1_BB1_BBB1, TestTier.B1_BB1_BBB1));
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.B1_BB1_BBB2, TestTier.B1_BB1_BBB2));
+    assertTrue(m_tierTree.isAvailableImpl(TestTier.B1_BB1_BBB3, TestTier.B1_BB1_BBB3));
+  }
+
+  @Test
+  public void testPath() {
+    // to is null
+    assertEquals(List.of(), m_tierTree.topDownPathImpl(null, null));
+    assertEquals(List.of(), m_tierTree.topDownPathImpl(TestTier.A1, null));
+
+    // no path possible                  
+    assertEquals(List.of(), m_tierTree.topDownPathImpl(TestTier.A1, TestTier.B1_BB1_BBB1));
+    assertEquals(List.of(), m_tierTree.topDownPathImpl(TestTier.A1_AA1_AAA1, TestTier.A1_AA1_AAA3));
+
+    // path possible
+    assertEquals(List.of(TestTier.A1, TestTier.A1_AA2, TestTier.A1_AA2_AAA6), m_tierTree.topDownPathImpl(TestTier.A1, TestTier.A1_AA2_AAA6));
+    assertEquals(List.of(TestTier.B1, TestTier.B1_BB1, TestTier.B1_BB1_BBB3), m_tierTree.topDownPathImpl(TestTier.B1, TestTier.B1_BB1_BBB3));
+
+    assertEquals(List.of(TestTier.Root, TestTier.A1, TestTier.A1_AA2, TestTier.A1_AA2_AAA6), m_tierTree.topDownPathImpl(null, TestTier.A1_AA2_AAA6));
+    assertEquals(List.of(TestTier.Root, TestTier.B1, TestTier.B1_BB1, TestTier.B1_BB1_BBB3), m_tierTree.topDownPathImpl(null, TestTier.B1_BB1_BBB3));
+  }
+
+  @Test
+  @ExtendWithTestingEnvironment(
+      primary = @ExtendWithJavaEnvironmentFactory(ScoutFullJavaEnvironmentFactory.class),
+      dto = @ExtendWithJavaEnvironmentFactory(ScoutSharedJavaEnvironmentFactory.class))
+  public void testTierOf(TestingEnvironment env) {
+    testTierOf(null, "something else", env);
+    testTierOf(TestTier.A1_AA2_AAA6, "AAA6", env);
+    testTierOf(TestTier.A1_AA3, "AA3", env);
+    testTierOf(TestTier.A1, "A1", env);
+  }
+
+  private void testTierOf(ITier<?> expected, String fqn, TestingEnvironment env) {
+    assertEquals(expected, m_tierTree.tierOfImpl(fqn::equals, env.primaryEnvironment()::api).orElse(null));
+  }
+
+  private enum TestTier implements ITier<IScoutApi> {
+    Root,
+    // Level 1
+    A1, B1, C1,
+    // Level 2
+    A1_AA1, A1_AA2, A1_AA3,
+    B1_BB1, B1_BB2, B1_BB3,
+    C1_CC1, C1_CC2, C1_CC3,
+    // Level 3
+    A1_AA1_AAA1, A1_AA1_AAA2, A1_AA1_AAA3,
+    A1_AA2_AAA4, A1_AA2_AAA5, A1_AA2_AAA6,
+    A1_AA3_AAA7, A1_AA3_AAA8, A1_AA3_AAA9,
+    B1_BB1_BBB1, B1_BB1_BBB2, B1_BB1_BBB3,
+    C1_CC1_CCC1, C1_CC1_CCC2, C1_CC1_CCC3;
+
+    @Override
+    public String tierName() {
+      return name();
+    }
+
+    @Override
+    public String getLookupFqn(IScoutApi api) {
+      return lastElement(arrayList(tierName().split("_")));
+    }
+
+    @Override
+    public Class<IScoutApi> getApiClass() {
+      return IScoutApi.class;
+    }
+  }
+
+  private enum AddDependencyTier implements ITier<IScoutApi> {
+    // Level 3
+    C1_CC2_CCC4, C1_CC2_CCC5, C1_CC2_CCC6;
+
+    @Override
+    public String tierName() {
+      return name();
+    }
+
+    @Override
+    public String getLookupFqn(IScoutApi api) {
+      return null;
+    }
+
+    @Override
+    public Class<IScoutApi> getApiClass() {
+      return IScoutApi.class;
+    }
+  }
+}

--- a/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/lookupcall/LookupCallNewOperation.java
+++ b/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/lookupcall/LookupCallNewOperation.java
@@ -30,6 +30,7 @@ import org.eclipse.scout.sdk.core.s.environment.IFuture;
 import org.eclipse.scout.sdk.core.s.environment.IProgress;
 import org.eclipse.scout.sdk.core.s.generator.annotation.ScoutAnnotationGenerator;
 import org.eclipse.scout.sdk.core.s.testcase.TestGenerator;
+import org.eclipse.scout.sdk.core.s.util.ITier;
 import org.eclipse.scout.sdk.core.s.util.ScoutTier;
 import org.eclipse.scout.sdk.core.util.Ensure;
 import org.eclipse.scout.sdk.core.util.JavaTypes;
@@ -112,7 +113,7 @@ public class LookupCallNewOperation implements BiConsumer<IEnvironment, IProgres
     var testEnv = testSourceFolder.javaEnvironment();
 
     var scoutApi = testEnv.requireApi(IScoutApi.class);
-    var targetTier = ScoutTier.valueOf(testEnv)
+    var targetTier = ITier.of(testEnv)
         .orElseThrow(() -> newFail("Test-source-folder {} has no access to Scout classes", testSourceFolder));
     var testPackage = ScoutTier.Shared.convert(targetTier, getPackage());
     var isClient = ScoutTier.Client.isIncludedIn(targetTier);

--- a/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/util/ITier.java
+++ b/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/util/ITier.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.sdk.core.s.util;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import org.eclipse.scout.sdk.core.apidef.IApiSpecification;
+import org.eclipse.scout.sdk.core.apidef.OptApiFunction;
+import org.eclipse.scout.sdk.core.model.api.IJavaElement;
+import org.eclipse.scout.sdk.core.model.api.IJavaEnvironment;
+import org.eclipse.scout.sdk.core.util.Strings;
+
+public interface ITier<A extends IApiSpecification> extends Predicate<IJavaElement> {
+
+  /**
+   * The name of the tier. Used to convert e.g. package names from on tier to another (see
+   * {@link #convert(ITier, String)}).
+   */
+  String tierName();
+
+  /**
+   * Get a fully qualified name of an element for a given API to test whether an object is a tier or not (see
+   * {@link #of(IJavaElement)}, {@link #of(IJavaEnvironment)}, {@link #of(Predicate, OptApiFunction)}).
+   */
+  String getLookupFqn(A api);
+
+  /**
+   * Get the {@link Class} corresponding to {@link A}.
+   */
+  Class<A> getApiClass();
+
+  /**
+   * Get a fully qualified name of an element for a strategy to resolve an API to test whether an object is a tier or
+   * not (see {@link #of(IJavaElement)}, {@link #of(IJavaEnvironment)}, {@link #of(Predicate, OptApiFunction)}).
+   */
+  default String getLookupFqn(OptApiFunction optApiFunction) {
+    return Optional.ofNullable(optApiFunction)
+        .flatMap(oaf -> oaf.apply(getApiClass()))
+        .map(this::getLookupFqn)
+        .orElse(null);
+  }
+
+  /**
+   * Tests if the tier of this instance is included in the tier of the given {@link IJavaElement}.
+   *
+   * @return {@code true} if the tier of the given {@link IJavaElement} includes all elements of this tier.
+   *         {@code false} otherwise or if the given {@link IJavaElement} does not belong to a tier.
+   * @see #isIncludedIn(ITier)
+   */
+  @Override
+  default boolean test(IJavaElement element) {
+    return of(element)
+        .filter(this::isIncludedIn)
+        .isPresent();
+  }
+
+  /**
+   * Tests if the tier of this instance is included in the given tier.<br>
+   * <br>
+   * <b>Examples:</b><br>
+   * {@code ScoutTier.Shared.isIncludedIn(ScoutTier.Client) == true}<br>
+   * {@code ScoutTier.Client.isIncludedIn(ScoutTier.HtmlUi) == true}<br>
+   * {@code ScoutTier.Server.isIncludedIn(ScoutTier.Server) == true}<br>
+   * {@code ScoutTier.Server.isIncludedIn(ScoutTier.Shared) == false}<br>
+   * {@code ScoutTier.HtmlUi.isIncludedIn(ScoutTier.Client) == false}<br>
+   * {@code ScoutTier.Shared.isIncludedIn(null) == false}
+   *
+   * @param tier
+   *          The other tier to test against or {@code null}.
+   * @return {@code true} if the given tier includes all elements of this tier. {@code false} otherwise or if the given
+   *         tier is {@code null}.
+   */
+  default boolean isIncludedIn(ITier<?> tier) {
+    return TierTree.isAvailable(tier, this);
+  }
+
+  /**
+   * Get the corresponding tier for the given {@link IJavaElement}.
+   */
+  static Optional<ITier<?>> of(IJavaElement element) {
+    return TierTree.tierOf(element);
+  }
+
+  /**
+   * Get the corresponding tier for the given {@link IJavaEnvironment}.
+   */
+  static Optional<ITier<?>> of(IJavaEnvironment env) {
+    return TierTree.tierOf(env);
+  }
+
+  /**
+   * Get the corresponding tier for the given strategies.
+   * 
+   * @param typeLookupStrategy
+   *          a tier will use this {@link Predicate} to check if its lookupFqn (see
+   *          {@link #getLookupFqn(OptApiFunction)}) is available
+   * @param optApiFunction
+   *          a function that provides an implementation of a given API class (see {@link #getApiClass()})
+   */
+  static Optional<ITier<?>> of(Predicate<String> typeLookupStrategy, OptApiFunction optApiFunction) {
+    return TierTree.tierOf(typeLookupStrategy, optApiFunction);
+  }
+
+  /**
+   * Converts the given {@link String} from the {@link #tierName()} of this {@link ITier} to the {@link #tierName()} of
+   * the given {@link ITier}.<br>
+   * <br>
+   * <b>Example :</b><br>
+   * {@code ScoutTier.Client.convert(ScoutTier.Server, "org.eclipse.scout.client.test.app")} ->
+   * {@code "org.eclipse.scout.server.test.app"}
+   *
+   * @param to
+   *          The {@link ITier} to which the given name should be converted.
+   * @param name
+   *          The name to convert.
+   * @return The converted {@link String}.
+   */
+  default String convert(ITier<?> to, String name) {
+    if (Strings.isBlank(name) || to == null) {
+      return name;
+    }
+    if (to == this) {
+      return name;
+    }
+    return Strings.replace(name, '.' + tierName(), '.' + to.tierName()).toString();
+  }
+}

--- a/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/util/ScoutTier.java
+++ b/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/util/ScoutTier.java
@@ -11,12 +11,9 @@
 package org.eclipse.scout.sdk.core.s.util;
 
 import java.util.Optional;
-import java.util.function.Predicate;
+import java.util.function.Function;
 
-import org.eclipse.scout.sdk.core.model.api.IJavaElement;
-import org.eclipse.scout.sdk.core.model.api.IJavaEnvironment;
 import org.eclipse.scout.sdk.core.s.apidef.IScoutApi;
-import org.eclipse.scout.sdk.core.util.Strings;
 
 /**
  * <h3>{@link ScoutTier}</h3> Helper class to detect and convert scout tiers.
@@ -24,159 +21,56 @@ import org.eclipse.scout.sdk.core.util.Strings;
  * @since 5.2.0
  */
 @SuppressWarnings("squid:S00115")
-public enum ScoutTier implements Predicate<IJavaElement> {
+public enum ScoutTier implements ITier<IScoutApi> {
 
   /**
    * Scout Client Tier
    */
-  Client,
+  Client("client", api -> api.IClientSession().fqn()),
 
   /**
    * Scout Shared Tier
    */
-  Shared,
+  Shared("shared", api -> api.ISession().fqn()),
 
   /**
    * Scout Server Tier
    */
-  Server,
+  Server("server", api -> api.IServerSession().fqn()),
 
   /**
    * Scout HTML UI Tier
    */
-  HtmlUi;
+  HtmlUi("ui.html", api -> api.UiServlet().fqn());
 
-  /**
-   * Tests if the tier of this instance is included in the tier of the given {@link IJavaElement}.
-   *
-   * @return {@code true} if the tier of the given {@link IJavaElement} includes all elements of this tier.
-   *         {@code false} otherwise or if the given {@link IJavaElement} does not belong to a Scout tier.
-   * @see #isIncludedIn(ScoutTier)
-   */
+  public static void initTierTree() {
+    TierTree.addDependency(ScoutTier.HtmlUi, ScoutTier.Client);
+    TierTree.addDependency(ScoutTier.Client, ScoutTier.Shared);
+    TierTree.addDependency(ScoutTier.Server, ScoutTier.Shared);
+  }
+
+  private final String m_tierName;
+  private final Function<IScoutApi, String> m_lookupFqnFunction;
+
+  ScoutTier(String tierName, Function<IScoutApi, String> lookupFqnFunction) {
+    m_tierName = tierName;
+    m_lookupFqnFunction = lookupFqnFunction;
+  }
+
   @Override
-  public boolean test(IJavaElement element) {
-    return valueOf(element)
-        .filter(this::isIncludedIn)
-        .isPresent();
-  }
-
-  /**
-   * Tests if the tier of this instance is included in the given tier.<br>
-   * <br>
-   * <b>Examples:</b><br>
-   * {@code ScoutTier.Shared.isIncludedIn(ScoutTier.Client) == true}<br>
-   * {@code ScoutTier.Client.isIncludedIn(ScoutTier.HtmlUi) == true}<br>
-   * {@code ScoutTier.Server.isIncludedIn(ScoutTier.Server) == true}<br>
-   * {@code ScoutTier.Server.isIncludedIn(ScoutTier.Shared) == false}<br>
-   * {@code ScoutTier.HtmlUi.isIncludedIn(ScoutTier.Client) == false}<br>
-   * {@code ScoutTier.Shared.isIncludedIn(null) == false}
-   *
-   * @param tierOfOtherElement
-   *          The other tier to test against or {@code null}.
-   * @return {@code true} if the given tier includes all elements of this tier. {@code false} otherwise or if the given
-   *         tier is {@code null}.
-   */
-  public boolean isIncludedIn(ScoutTier tierOfOtherElement) {
-    if (tierOfOtherElement == null) {
-      return false;
-    }
-    if (Shared == this) {
-      return true; // shared is always available if the other is not null
-    }
-    if (Client == this) {
-      return Client == tierOfOtherElement || HtmlUi == tierOfOtherElement;
-    }
-    return equals(tierOfOtherElement);
-  }
-
-  /**
-   * Gets the {@link ScoutTier} the given {@link IJavaElement} belongs to.
-   *
-   * @param element
-   *          The {@link IJavaElement} for which the {@link ScoutTier} should be calculated.
-   * @return The {@link ScoutTier} the given element belongs to or {@code null} if it does not belong to a
-   *         {@link ScoutTier}.
-   */
-  public static Optional<ScoutTier> valueOf(IJavaElement element) {
-    return Optional.ofNullable(element)
-        .map(IJavaElement::javaEnvironment)
-        .flatMap(ScoutTier::valueOf);
-  }
-
-  public static Optional<ScoutTier> valueOf(IJavaEnvironment env) {
-    return Optional.ofNullable(env)
-        .flatMap(e -> e.api(IScoutApi.class))
-        .flatMap(api -> valueOf(env::exists, api));
-  }
-
-  public static Optional<ScoutTier> valueOf(Predicate<String> typeLookupStrategy, IScoutApi api) {
-    if (typeLookupStrategy == null || api == null) {
-      return Optional.empty();
-    }
-
-    var uiAvailable = typeLookupStrategy.test(api.UiServlet().fqn());
-    if (uiAvailable) {
-      return Optional.of(HtmlUi);
-    }
-
-    var clientAvailable = typeLookupStrategy.test(api.IClientSession().fqn());
-    if (clientAvailable) {
-      return Optional.of(Client);
-    }
-
-    var serverAvailable = typeLookupStrategy.test(api.IServerSession().fqn());
-    if (serverAvailable) {
-      return Optional.of(Server);
-    }
-
-    var sharedAvailable = typeLookupStrategy.test(api.ISession().fqn());
-    if (sharedAvailable) {
-      return Optional.of(Shared);
-    }
-
-    return Optional.empty();
-  }
-
-  /**
-   * Gets the name of this {@link ScoutTier}.
-   *
-   * @return E.g. "client" or "ui.html"
-   */
   public String tierName() {
-    switch (this) {
-      case Client:
-        return "client";
-      case Shared:
-        return "shared";
-      case HtmlUi:
-        return "ui.html";
-      default:
-        return "server";
-    }
+    return m_tierName;
   }
 
-  /**
-   * Converts the given {@link String} from the {@link #tierName()} of this {@link ScoutTier} to the {@link #tierName()}
-   * of the given {@link ScoutTier}.<br>
-   * <br>
-   * <b>Example :</b><br>
-   * {@code ScoutTier.Client.convert(ScoutTier.Server, "org.eclipse.scout.client.test.app")} ->
-   * {@code "org.eclipse.scout.server.test.app"}
-   *
-   * @param to
-   *          The {@link ScoutTier} to which the given name should be converted.
-   * @param name
-   *          The name to convert.
-   * @return The converted {@link String}.
-   */
-  public String convert(ScoutTier to, String name) {
-    if (Strings.isBlank(name) || to == null) {
-      return name;
-    }
-    if (to == this) {
-      return name;
-    }
-    return Strings.replace(name, '.' + tierName(), '.' + to.tierName()).toString();
+  @Override
+  public String getLookupFqn(IScoutApi api) {
+    return Optional.ofNullable(api)
+        .map(m_lookupFqnFunction)
+        .orElse(null);
   }
 
+  @Override
+  public Class<IScoutApi> getApiClass() {
+    return IScoutApi.class;
+  }
 }

--- a/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/util/TierTree.java
+++ b/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/util/TierTree.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.sdk.core.s.util;
+
+import static java.util.Collections.emptyList;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.eclipse.scout.sdk.core.apidef.OptApiFunction;
+import org.eclipse.scout.sdk.core.model.api.IJavaElement;
+import org.eclipse.scout.sdk.core.model.api.IJavaEnvironment;
+import org.eclipse.scout.sdk.core.util.Ensure;
+import org.eclipse.scout.sdk.core.util.visitor.DefaultDepthFirstVisitor;
+import org.eclipse.scout.sdk.core.util.visitor.TreeTraversals;
+
+public final class TierTree {
+
+  private static final TierTree INSTANCE = create();
+
+  private TierNode m_root;
+  private final Map<ITier<?>, TierNode> m_tiers = new HashMap<>();
+
+  static {
+    ScoutTier.initTierTree();
+  }
+
+  private TierTree() {
+  }
+
+  static TierTree create() {
+    return new TierTree();
+  }
+
+  public static boolean addDependency(ITier<?> tier, ITier<?> dependency) {
+    return INSTANCE.addDependencyImpl(tier, dependency);
+  }
+
+  boolean addDependencyImpl(ITier<?> tier, ITier<?> dependency) {
+    Ensure.notNull(tier, "tier is null");
+    Ensure.notNull(dependency, "dependency is null");
+
+    if (m_tiers.containsKey(tier) && m_tiers.containsKey(dependency)) {
+      return false;
+    }
+    if (!m_tiers.isEmpty() && !m_tiers.containsKey(tier) && !m_tiers.containsKey(dependency)) {
+      return false;
+    }
+
+    var tierNode = m_tiers.computeIfAbsent(tier, TierNode::of);
+    var dependencyNode = m_tiers.computeIfAbsent(dependency, TierNode::of);
+
+    if (m_root == null || m_root.isTier(tier)) {
+      m_root = dependencyNode;
+    }
+
+    return dependencyNode.addChildren(tierNode);
+  }
+
+  boolean hasDependencyImpl(ITier<?> tier, ITier<?> dependency) {
+    var tierNode = m_tiers.get(tier);
+    if (tierNode == null) {
+      return false;
+    }
+
+    var currentNode = tierNode.getParent();
+
+    while (currentNode != null) {
+      if (currentNode.isTier(dependency)) {
+        return true;
+      }
+      currentNode = currentNode.getParent();
+    }
+
+    return false;
+  }
+
+  static boolean isAvailable(ITier<?> tier, ITier<?> other) {
+    return INSTANCE.isAvailableImpl(tier, other);
+  }
+
+  boolean isAvailableImpl(ITier<?> tier, ITier<?> other) {
+    if (!m_tiers.containsKey(tier)) {
+      return false;
+    }
+
+    return tier.equals(other) || hasDependencyImpl(tier, other);
+  }
+
+  public static List<ITier<?>> topDownPath(ITier<?> top, ITier<?> bottom) {
+    return INSTANCE.topDownPathImpl(top, bottom);
+  }
+
+  List<ITier<?>> topDownPathImpl(ITier<?> top, ITier<?> bottom) {
+    var toNode = m_tiers.get(bottom);
+    if (toNode == null) {
+      return emptyList();
+    }
+
+    List<ITier<?>> path = new ArrayList<>();
+    var currentNode = toNode;
+    path.add(currentNode.getTier());
+
+    do {
+      currentNode = currentNode.getParent();
+      if (currentNode != null) {
+        path.add(0, currentNode.getTier());
+      }
+    }
+    while (currentNode != null && !currentNode.isTier(top));
+
+    if (currentNode == null && top != null) {
+      // top was not found between bottom and root -> no path possible
+      return emptyList();
+    }
+
+    return Collections.unmodifiableList(path);
+  }
+
+  /**
+   * Gets the {@link ITier} the given {@link IJavaElement} belongs to.
+   *
+   * @param element
+   *          The {@link IJavaElement} for which the {@link ITier} should be calculated.
+   * @return The {@link ITier} the given element belongs to or {@code null} if it does not belong to a {@link ITier}.
+   */
+  static Optional<ITier<?>> tierOf(IJavaElement element) {
+    return Optional.ofNullable(element)
+        .map(IJavaElement::javaEnvironment)
+        .flatMap(TierTree::tierOf);
+  }
+
+  static Optional<ITier<?>> tierOf(IJavaEnvironment env) {
+    return Optional.ofNullable(env)
+        .flatMap(e -> tierOf(e::exists, e::api));
+  }
+
+  static Optional<ITier<?>> tierOf(Predicate<String> typeLookupStrategy, OptApiFunction optApiFunction) {
+    return INSTANCE.tierOfImpl(typeLookupStrategy, optApiFunction);
+  }
+
+  Optional<ITier<?>> tierOfImpl(Predicate<String> typeLookupStrategy, OptApiFunction optApiFunction) {
+    var tier = new AtomicReference<ITier<?>>();
+    TreeTraversals.create(new DefaultDepthFirstVisitor<>() {
+      @Override
+      public boolean postVisit(TierNode tierNode, int level, int index) {
+        if (typeLookupStrategy.test(tierNode.getTier().getLookupFqn(optApiFunction))) {
+          tier.set(tierNode.getTier());
+          return false;
+        }
+        return true;
+      }
+    }, TierNode::children).traverse(m_root);
+
+    return Optional.ofNullable(tier.get());
+  }
+
+  private static final class TierNode {
+    private final ITier<?> m_tier;
+    private TierNode m_parent;
+    private final Collection<TierNode> m_children = new HashSet<>();
+
+    private TierNode(ITier<?> tier) {
+      m_tier = Ensure.notNull(tier, "tier is null");
+    }
+
+    private static TierNode of(ITier<?> tier) {
+      return new TierNode(tier);
+    }
+
+    private ITier<?> getTier() {
+      return m_tier;
+    }
+
+    private boolean isTier(ITier<?> tier) {
+      return m_tier.equals(tier);
+    }
+
+    private void setParent(TierNode parent) {
+      m_parent = parent;
+    }
+
+    private TierNode getParent() {
+      return m_parent;
+    }
+
+    private Stream<TierNode> children() {
+      return m_children.stream();
+    }
+
+    private boolean addChildren(TierNode tierNode) {
+      tierNode.setParent(this);
+      return m_children.add(tierNode);
+    }
+  }
+}

--- a/org.eclipse.scout.sdk.core.test/src/test/java/org/eclipse/scout/sdk/core/util/StringsTest.java
+++ b/org.eclipse.scout.sdk.core.test/src/test/java/org/eclipse/scout/sdk/core/util/StringsTest.java
@@ -13,6 +13,7 @@ package org.eclipse.scout.sdk.core.util;
 import static java.lang.System.lineSeparator;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static org.eclipse.scout.sdk.core.util.Strings.camelCaseToScreamingSnakeCase;
 import static org.eclipse.scout.sdk.core.util.Strings.capitalize;
 import static org.eclipse.scout.sdk.core.util.Strings.compareTo;
 import static org.eclipse.scout.sdk.core.util.Strings.countMatches;
@@ -32,10 +33,12 @@ import static org.eclipse.scout.sdk.core.util.Strings.levenshteinDistance;
 import static org.eclipse.scout.sdk.core.util.Strings.nextLineEnd;
 import static org.eclipse.scout.sdk.core.util.Strings.notBlank;
 import static org.eclipse.scout.sdk.core.util.Strings.notEmpty;
+import static org.eclipse.scout.sdk.core.util.Strings.removePrefix;
 import static org.eclipse.scout.sdk.core.util.Strings.removeSuffix;
 import static org.eclipse.scout.sdk.core.util.Strings.repeat;
 import static org.eclipse.scout.sdk.core.util.Strings.replace;
 import static org.eclipse.scout.sdk.core.util.Strings.replaceEach;
+import static org.eclipse.scout.sdk.core.util.Strings.screamingSnakeCaseToCamelCase;
 import static org.eclipse.scout.sdk.core.util.Strings.toCharArray;
 import static org.eclipse.scout.sdk.core.util.Strings.toStringLiteral;
 import static org.eclipse.scout.sdk.core.util.Strings.trim;
@@ -693,5 +696,43 @@ public class StringsTest {
     assertEquals("ab", removeSuffix("abcdef", "cdef"));
     assertEquals("abcDef", removeSuffix("abcDef", "cdef"));
     assertEquals("ab", removeSuffix("abcDef", "cdef", false));
+  }
+
+  @Test
+  public void testRemovePrefixSuffix() {
+    assertNull(removePrefix(null, ""));
+    assertEquals("", removePrefix("", ""));
+    assertEquals("ab", removePrefix("ab", ""));
+    assertEquals("ab", removePrefix("ab", null));
+    assertEquals("", removePrefix("", "ab"));
+    assertEquals("bc", removePrefix("abc", "a"));
+    assertEquals("ef", removePrefix("abcdef", "abcd"));
+    assertEquals("abcDef", removePrefix("abcDef", "abcd"));
+    assertEquals("ef", removePrefix("abcDef", "abcd", false));
+  }
+
+  @Test
+  public void testCamelCaseToScreamingSnakeCase() {
+    assertNull(camelCaseToScreamingSnakeCase(null));
+    assertEquals("", camelCaseToScreamingSnakeCase(""));
+    assertEquals(" ", camelCaseToScreamingSnakeCase(" "));
+    assertEquals("FOO", camelCaseToScreamingSnakeCase("foo"));
+    assertEquals("FOO", camelCaseToScreamingSnakeCase("FOO"));
+    assertEquals("FOO_BAR", camelCaseToScreamingSnakeCase("fooBar"));
+    assertEquals("FOO_BAR", camelCaseToScreamingSnakeCase("fooBAR"));
+    assertEquals("FOO_BAR_SEE", camelCaseToScreamingSnakeCase("fooBarSee"));
+    assertEquals("FOO_BAR_SEE", camelCaseToScreamingSnakeCase("fooBARSee"));
+    assertEquals("FOO BAR SEE", camelCaseToScreamingSnakeCase("foo bar see"));
+  }
+
+  @Test
+  public void testScreamingSnakeCaseToCamelCase() {
+    assertNull(screamingSnakeCaseToCamelCase(null));
+    assertEquals("", screamingSnakeCaseToCamelCase(""));
+    assertEquals(" ", screamingSnakeCaseToCamelCase(" "));
+    assertEquals("Foo", screamingSnakeCaseToCamelCase("FOO"));
+    assertEquals("FooBar", screamingSnakeCaseToCamelCase("FOO_BAR"));
+    assertEquals("FooBarSee", screamingSnakeCaseToCamelCase("FOO_BAR_SEE"));
+    assertEquals("Foo bar see", screamingSnakeCaseToCamelCase("FOO BAR SEE"));
   }
 }

--- a/org.eclipse.scout.sdk.core/src/main/java/org/eclipse/scout/sdk/core/apidef/Api.java
+++ b/org.eclipse.scout.sdk.core/src/main/java/org/eclipse/scout/sdk/core/apidef/Api.java
@@ -53,6 +53,7 @@ public final class Api {
   public enum ChildElementType {
 
     METHOD_NAME("MethodName"), // Methods in the type
+    FIELD_NAME("FieldName"), // Fields in the type
     TYPE_PARAM_INDEX("TypeParamIndex"), // Type Parameter indices
     ANNOTATION_ELEMENT_NAME("ElementName"), // Annotation elements
     OTHER("other"); // all other methods

--- a/org.eclipse.scout.sdk.core/src/main/java/org/eclipse/scout/sdk/core/apidef/OptApiFunction.java
+++ b/org.eclipse.scout.sdk.core/src/main/java/org/eclipse/scout/sdk/core/apidef/OptApiFunction.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2010-2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
+package org.eclipse.scout.sdk.core.apidef;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Represents a generic {@link Function} that takes a {@link Class}<{@code T}> and returns an
+ * {@link Optional}<{@code T}> where {@code T extends }{@link IApiSpecification}.
+ */
+@FunctionalInterface
+public interface OptApiFunction {
+  <T extends IApiSpecification> Optional<T> apply(Class<T> c);
+}

--- a/org.eclipse.scout.sdk.core/src/main/java/org/eclipse/scout/sdk/core/util/JavaTypes.java
+++ b/org.eclipse.scout.sdk.core/src/main/java/org/eclipse/scout/sdk/core/util/JavaTypes.java
@@ -144,6 +144,10 @@ public final class JavaTypes {
    */
   public static final char C_SPACE = ' ';
   /**
+   * The Java lambda arrow. Value is {@code ->}
+   */
+  public static final String LAMBDA_ARROW = "->";
+  /**
    * The Java {@code extends} keyword.
    */
   public static final String EXTENDS = "extends";

--- a/org.eclipse.scout.sdk.s2e.ui/src/main/java/org/eclipse/scout/sdk/s2e/ui/fields/FieldToolkit.java
+++ b/org.eclipse.scout.sdk.s2e.ui/src/main/java/org/eclipse/scout/sdk/s2e/ui/fields/FieldToolkit.java
@@ -15,7 +15,7 @@ import java.util.function.Predicate;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.scout.sdk.core.s.nls.manager.TranslationManager;
-import org.eclipse.scout.sdk.core.s.util.ScoutTier;
+import org.eclipse.scout.sdk.core.s.util.ITier;
 import org.eclipse.scout.sdk.s2e.ui.fields.proposal.ProposalTextField;
 import org.eclipse.scout.sdk.s2e.ui.fields.proposal.content.JavaProjectContentProvider;
 import org.eclipse.scout.sdk.s2e.ui.fields.proposal.content.PackageContentProvider;
@@ -29,7 +29,7 @@ import org.eclipse.scout.sdk.s2e.ui.fields.text.TextField;
 import org.eclipse.scout.sdk.s2e.ui.util.S2eUiUtils;
 import org.eclipse.scout.sdk.s2e.util.JdtUtils.PublicAbstractPrimaryTypeFilter;
 import org.eclipse.scout.sdk.s2e.util.JdtUtils.PublicPrimaryTypeFilter;
-import org.eclipse.scout.sdk.s2e.util.S2eScoutTier;
+import org.eclipse.scout.sdk.s2e.util.S2eTier;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
@@ -108,13 +108,13 @@ public final class FieldToolkit {
     return proposalField;
   }
 
-  public static ProposalTextField createSourceFolderField(Composite parent, String label, ScoutTier tier) {
+  public static ProposalTextField createSourceFolderField(Composite parent, String label, ITier<?> tier) {
     return createSourceFolderField(parent, label, tier, TextField.DEFAULT_LABEL_WIDTH);
   }
 
-  public static ProposalTextField createSourceFolderField(Composite parent, String label, ScoutTier tier, int labelWidth) {
+  public static ProposalTextField createSourceFolderField(Composite parent, String label, ITier<?> tier, int labelWidth) {
     var proposalField = createProposalField(parent, label, TextField.TYPE_LABEL, labelWidth);
-    var provider = new SourceFolderContentProvider(S2eScoutTier.wrap(tier));
+    var provider = new SourceFolderContentProvider(S2eTier.wrap(tier));
     proposalField.setContentProvider(provider);
     proposalField.setLabelProvider(provider);
     return proposalField;

--- a/org.eclipse.scout.sdk.s2e.ui/src/main/java/org/eclipse/scout/sdk/s2e/ui/internal/form/FormNewWizardPage.java
+++ b/org.eclipse.scout.sdk.s2e.ui/src/main/java/org/eclipse/scout/sdk/s2e/ui/internal/form/FormNewWizardPage.java
@@ -30,7 +30,7 @@ import org.eclipse.scout.sdk.s2e.ui.fields.proposal.ProposalTextField;
 import org.eclipse.scout.sdk.s2e.ui.util.PackageContainer;
 import org.eclipse.scout.sdk.s2e.ui.wizard.AbstractCompilationUnitNewWizardPage;
 import org.eclipse.scout.sdk.s2e.util.JdtUtils;
-import org.eclipse.scout.sdk.s2e.util.S2eScoutTier;
+import org.eclipse.scout.sdk.s2e.util.S2eTier;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -128,8 +128,8 @@ public class FormNewWizardPage extends AbstractCompilationUnitNewWizardPage {
       return;
     }
 
-    setServerSourceFolder(S2eScoutTier.wrap(ScoutTier.Client).convert(ScoutTier.Server, clientSourceFolder).orElse(null));
-    setSharedSourceFolder(S2eScoutTier.wrap(ScoutTier.Client).convert(ScoutTier.Shared, clientSourceFolder).orElse(null));
+    setServerSourceFolder(S2eTier.wrap(ScoutTier.Client).convert(ScoutTier.Server, clientSourceFolder).orElse(null));
+    setSharedSourceFolder(S2eTier.wrap(ScoutTier.Client).convert(ScoutTier.Shared, clientSourceFolder).orElse(null));
   }
 
   @Override

--- a/org.eclipse.scout.sdk.s2e.ui/src/main/java/org/eclipse/scout/sdk/s2e/ui/internal/jaxws/editor/WebServiceEditor.java
+++ b/org.eclipse.scout.sdk.s2e.ui/src/main/java/org/eclipse/scout/sdk/s2e/ui/internal/jaxws/editor/WebServiceEditor.java
@@ -54,7 +54,7 @@ import org.eclipse.scout.sdk.s2e.operation.jaxws.RebuildArtifactsOperation;
 import org.eclipse.scout.sdk.s2e.ui.internal.jaxws.WebServiceNewWizard;
 import org.eclipse.scout.sdk.s2e.util.ApiHelper;
 import org.eclipse.scout.sdk.s2e.util.JdtUtils;
-import org.eclipse.scout.sdk.s2e.util.S2eScoutTier;
+import org.eclipse.scout.sdk.s2e.util.S2eTier;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Widget;
@@ -95,7 +95,7 @@ public class WebServiceEditor extends FormEditor {
       return;
     }
 
-    if (!S2eScoutTier.wrap(ScoutTier.Server).test(getJavaProject())) {
+    if (!S2eTier.wrap(ScoutTier.Server).test(getJavaProject())) {
       showError("Invalid project type: " + getJavaProject().getElementName() + " is not a server project", new IllegalArgumentException());
       return;
     }

--- a/org.eclipse.scout.sdk.s2e.ui/src/main/java/org/eclipse/scout/sdk/s2e/ui/internal/lookupcall/LookupCallNewWizardPage.java
+++ b/org.eclipse.scout.sdk.s2e.ui/src/main/java/org/eclipse/scout/sdk/s2e/ui/internal/lookupcall/LookupCallNewWizardPage.java
@@ -36,7 +36,7 @@ import org.eclipse.scout.sdk.s2e.ui.util.PackageContainer;
 import org.eclipse.scout.sdk.s2e.ui.wizard.AbstractCompilationUnitNewWizardPage;
 import org.eclipse.scout.sdk.s2e.util.JdtUtils;
 import org.eclipse.scout.sdk.s2e.util.JdtUtils.PublicAbstractPrimaryTypeFilter;
-import org.eclipse.scout.sdk.s2e.util.S2eScoutTier;
+import org.eclipse.scout.sdk.s2e.util.S2eTier;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.PlatformUI;
@@ -200,7 +200,7 @@ public class LookupCallNewWizardPage extends AbstractCompilationUnitNewWizardPag
       return;
     }
 
-    setServerSourceFolder(S2eScoutTier.wrap(ScoutTier.Shared).convert(ScoutTier.Server, sharedSourceFolder).orElse(null));
+    setServerSourceFolder(S2eTier.wrap(ScoutTier.Shared).convert(ScoutTier.Server, sharedSourceFolder).orElse(null));
   }
 
   protected void handleServerJavaProjectChanged() {

--- a/org.eclipse.scout.sdk.s2e.ui/src/main/java/org/eclipse/scout/sdk/s2e/ui/internal/page/PageNewWizardPage.java
+++ b/org.eclipse.scout.sdk.s2e.ui/src/main/java/org/eclipse/scout/sdk/s2e/ui/internal/page/PageNewWizardPage.java
@@ -32,7 +32,7 @@ import org.eclipse.scout.sdk.s2e.ui.fields.proposal.content.StrictHierarchyTypeC
 import org.eclipse.scout.sdk.s2e.ui.util.PackageContainer;
 import org.eclipse.scout.sdk.s2e.ui.wizard.AbstractCompilationUnitNewWizardPage;
 import org.eclipse.scout.sdk.s2e.util.JdtUtils;
-import org.eclipse.scout.sdk.s2e.util.S2eScoutTier;
+import org.eclipse.scout.sdk.s2e.util.S2eTier;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -171,8 +171,8 @@ public class PageNewWizardPage extends AbstractCompilationUnitNewWizardPage {
       return;
     }
 
-    setServerSourceFolder(S2eScoutTier.wrap(ScoutTier.Client).convert(ScoutTier.Server, clientSourceFolder).orElse(null));
-    setSharedSourceFolder(S2eScoutTier.wrap(ScoutTier.Client).convert(ScoutTier.Shared, clientSourceFolder).orElse(null));
+    setServerSourceFolder(S2eTier.wrap(ScoutTier.Client).convert(ScoutTier.Server, clientSourceFolder).orElse(null));
+    setSharedSourceFolder(S2eTier.wrap(ScoutTier.Client).convert(ScoutTier.Shared, clientSourceFolder).orElse(null));
   }
 
   @Override

--- a/org.eclipse.scout.sdk.s2e.ui/src/main/java/org/eclipse/scout/sdk/s2e/ui/wizard/AbstractCompilationUnitNewWizardPage.java
+++ b/org.eclipse.scout.sdk.s2e.ui/src/main/java/org/eclipse/scout/sdk/s2e/ui/wizard/AbstractCompilationUnitNewWizardPage.java
@@ -30,7 +30,7 @@ import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.scout.sdk.core.apidef.ITypeNameSupplier;
 import org.eclipse.scout.sdk.core.log.SdkLog;
 import org.eclipse.scout.sdk.core.s.apidef.IScoutApi;
-import org.eclipse.scout.sdk.core.s.util.ScoutTier;
+import org.eclipse.scout.sdk.core.s.util.ITier;
 import org.eclipse.scout.sdk.core.util.Ensure;
 import org.eclipse.scout.sdk.core.util.JavaTypes;
 import org.eclipse.scout.sdk.core.util.Strings;
@@ -68,7 +68,7 @@ public abstract class AbstractCompilationUnitNewWizardPage extends AbstractWizar
 
   public static final String PREF_SUPER_TYPE = "superType";
 
-  private final ScoutTier m_sourceFolderTier;
+  private final ITier<?> m_sourceFolderTier;
   private IScoutApi m_scoutApi;
   private String m_superTypeDefaultBase;
   private String m_superTypeDefault;
@@ -82,7 +82,7 @@ public abstract class AbstractCompilationUnitNewWizardPage extends AbstractWizar
   private ProposalTextField m_superTypeField;
   private Group m_icuGroupField;
 
-  protected AbstractCompilationUnitNewWizardPage(String pageName, PackageContainer packageContainer, String readOnlySuffix, ScoutTier sourceFolderTier) {
+  protected AbstractCompilationUnitNewWizardPage(String pageName, PackageContainer packageContainer, String readOnlySuffix, ITier<?> sourceFolderTier) {
     super(Ensure.notNull(pageName));
     m_readOnlySuffix = Ensure.notNull(readOnlySuffix);
     m_sourceFolderTier = Ensure.notNull(sourceFolderTier);

--- a/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/codetype/CreateCodeTypeAction.kt
+++ b/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/codetype/CreateCodeTypeAction.kt
@@ -12,6 +12,7 @@ package org.eclipse.scout.sdk.s2i.codetype
 
 import com.intellij.psi.PsiClass
 import org.eclipse.scout.sdk.core.s.codetype.CodeTypeNewOperation
+import org.eclipse.scout.sdk.core.s.util.ITier
 import org.eclipse.scout.sdk.core.s.util.ScoutTier
 import org.eclipse.scout.sdk.s2i.EclipseScoutBundle
 import org.eclipse.scout.sdk.s2i.element.CreateElementAction
@@ -20,7 +21,7 @@ import org.eclipse.scout.sdk.s2i.toIdea
 
 class CreateCodeTypeAction : CreateElementAction<CodeTypeNewOperation>(EclipseScoutBundle.message("create.codetype"), EclipseScoutBundle.message("create.codetype.desc")) {
 
-    override fun startScoutTiers(): Collection<ScoutTier> = listOf(ScoutTier.Shared)
+    override fun startTiers(): Collection<ITier<*>> = listOf(ScoutTier.Shared)
 
     override fun operationClass(): Class<CodeTypeNewOperation> = CodeTypeNewOperation::class.java
 

--- a/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/element/CreateElementAction.kt
+++ b/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/element/CreateElementAction.kt
@@ -32,6 +32,7 @@ import com.intellij.util.concurrency.AppExecutorUtil
 import org.eclipse.scout.sdk.core.log.SdkLog
 import org.eclipse.scout.sdk.core.s.environment.IEnvironment
 import org.eclipse.scout.sdk.core.s.environment.IProgress
+import org.eclipse.scout.sdk.core.s.util.ITier
 import org.eclipse.scout.sdk.core.s.util.ScoutTier
 import org.eclipse.scout.sdk.core.util.Strings.capitalize
 import org.eclipse.scout.sdk.s2i.EclipseScoutBundle
@@ -161,14 +162,14 @@ abstract class CreateElementAction<OP : BiConsumer<IEnvironment, IProgress>>(val
             SdkLog.warning("No source folder could be determined for location '{}'", dir.virtualFile)
             return false
         }
-        if (!startScoutTiers().contains(sourceFolderHelper.tier())) {
-            SdkLog.warning("Location '{}' is not a {} module", dir.virtualFile, startScoutTiers().joinToString())
+        if (!startTiers().contains(sourceFolderHelper.tier())) {
+            SdkLog.warning("Location '{}' is not a {} module", dir.virtualFile, startTiers().joinToString())
             return false
         }
         return true
     }
 
-    protected open fun startScoutTiers(): Collection<ScoutTier> = listOf(ScoutTier.Client, ScoutTier.Shared, ScoutTier.Server)
+    protected open fun startTiers(): Collection<ITier<*>> = listOf(ScoutTier.Client, ScoutTier.Shared, ScoutTier.Server)
 
     protected abstract fun operationClass(): Class<OP>
 

--- a/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/element/ElementCreationManagerImplementor.kt
+++ b/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/element/ElementCreationManagerImplementor.kt
@@ -42,19 +42,19 @@ class ElementCreationManagerImplementor : ElementCreationManager {
                 op.entityName = elementName
                 op.clientPackage = sourceFolderHelper.tier()!!.convert(ScoutTier.Client, pkg)
 
-                op.clientSourceFolder = sourceFolderHelper.clientSourceFolder()
-                op.sharedSourceFolder = sourceFolderHelper.sharedSourceFolder()
-                op.serverSourceFolder = sourceFolderHelper.serverSourceFolder()
+                op.clientSourceFolder = sourceFolderHelper.sourceFolder(ScoutTier.Client)
+                op.sharedSourceFolder = sourceFolderHelper.sourceFolder(ScoutTier.Shared)
+                op.serverSourceFolder = sourceFolderHelper.sourceFolder(ScoutTier.Server)
 
-                op.sharedGeneratedSourceFolder = sourceFolderHelper.sharedGeneratedSourceFolder()
+                op.sharedGeneratedSourceFolder = sourceFolderHelper.generatedSourceFolder(ScoutTier.Shared)
 
-                op.clientTestSourceFolder = sourceFolderHelper.clientTestSourceFolder()
-                op.sharedTestSourceFolder = sourceFolderHelper.sharedTestSourceFolder()
-                op.serverTestSourceFolder = sourceFolderHelper.serverTestSourceFolder()
+                op.clientTestSourceFolder = sourceFolderHelper.testSourceFolder(ScoutTier.Client)
+                op.sharedTestSourceFolder = sourceFolderHelper.testSourceFolder(ScoutTier.Shared)
+                op.serverTestSourceFolder = sourceFolderHelper.testSourceFolder(ScoutTier.Server)
 
-                op.clientMainTestSourceFolder = sourceFolderHelper.clientMainTestSourceFolder()
-                op.sharedMainTestSourceFolder = sourceFolderHelper.sharedMainTestSourceFolder()
-                op.serverMainTestSourceFolder = sourceFolderHelper.serverMainTestSourceFolder()
+                op.clientMainTestSourceFolder = sourceFolderHelper.mainTestSourceFolder(ScoutTier.Client)
+                op.sharedMainTestSourceFolder = sourceFolderHelper.mainTestSourceFolder(ScoutTier.Shared)
+                op.serverMainTestSourceFolder = sourceFolderHelper.mainTestSourceFolder(ScoutTier.Server)
             })
         })
     }
@@ -68,24 +68,24 @@ class ElementCreationManagerImplementor : ElementCreationManager {
                 op.formName = elementNameWithSuffix(elementName, ISdkConstants.SUFFIX_FORM)
                 op.clientPackage = sourceFolderHelper.tier()!!.convert(ScoutTier.Client, pkg)
 
-                op.clientSourceFolder = sourceFolderHelper.clientSourceFolder()
-                op.sharedSourceFolder = sourceFolderHelper.sharedSourceFolder()
-                op.serverSourceFolder = sourceFolderHelper.serverSourceFolder()
-                op.formDataSourceFolder = sourceFolderHelper.sharedGeneratedSourceFolder() ?: sourceFolderHelper.sharedSourceFolder()
+                op.clientSourceFolder = sourceFolderHelper.sourceFolder(ScoutTier.Client)
+                op.sharedSourceFolder = sourceFolderHelper.sourceFolder(ScoutTier.Shared)
+                op.serverSourceFolder = sourceFolderHelper.sourceFolder(ScoutTier.Server)
+                op.formDataSourceFolder = sourceFolderHelper.generatedSourceFolder(ScoutTier.Shared) ?: sourceFolderHelper.sourceFolder(ScoutTier.Shared)
 
-                op.clientTestSourceFolder = sourceFolderHelper.clientTestSourceFolder()
-                op.serverTestSourceFolder = sourceFolderHelper.serverTestSourceFolder()
+                op.clientTestSourceFolder = sourceFolderHelper.testSourceFolder(ScoutTier.Client)
+                op.serverTestSourceFolder = sourceFolderHelper.testSourceFolder(ScoutTier.Server)
 
-                sourceFolderHelper.clientSourceFolder()?.javaEnvironment()?.api(IScoutApi::class.java)?.ifPresent {
+                sourceFolderHelper.sourceFolder(ScoutTier.Client)?.javaEnvironment()?.api(IScoutApi::class.java)?.ifPresent {
                     op.superType = it.AbstractForm().fqn()
                 }
-                sourceFolderHelper.serverSourceFolder()?.javaEnvironment()?.api(IScoutApi::class.java)?.ifPresent {
+                sourceFolderHelper.sourceFolder(ScoutTier.Server)?.javaEnvironment()?.api(IScoutApi::class.java)?.ifPresent {
                     op.serverSession = it.IServerSession().fqn()
                 }
 
-                op.isCreateFormData = sourceFolderHelper.sharedSourceFolder() != null
-                op.isCreatePermissions = sourceFolderHelper.sharedSourceFolder() != null
-                op.isCreateOrAppendService = sourceFolderHelper.sharedSourceFolder() != null && sourceFolderHelper.serverSourceFolder() != null
+                op.isCreateFormData = sourceFolderHelper.sourceFolder(ScoutTier.Shared) != null
+                op.isCreatePermissions = sourceFolderHelper.sourceFolder(ScoutTier.Shared) != null
+                op.isCreateOrAppendService = sourceFolderHelper.sourceFolder(ScoutTier.Shared) != null && sourceFolderHelper.sourceFolder(ScoutTier.Server) != null
             })
         })
     }
@@ -100,17 +100,17 @@ class ElementCreationManagerImplementor : ElementCreationManager {
                 op.pageName = elementNameWithSuffix(cleanedName, ISdkConstants.SUFFIX_PAGE_WITH_TABLE)
                 op.`package` = sourceFolderHelper.tier()!!.convert(ScoutTier.Client, pkg)
 
-                op.clientSourceFolder = sourceFolderHelper.clientSourceFolder()
-                op.sharedSourceFolder = sourceFolderHelper.sharedSourceFolder()
-                op.serverSourceFolder = sourceFolderHelper.serverSourceFolder()
-                op.pageDataSourceFolder = sourceFolderHelper.sharedGeneratedSourceFolder() ?: sourceFolderHelper.sharedSourceFolder()
+                op.clientSourceFolder = sourceFolderHelper.sourceFolder(ScoutTier.Client)
+                op.sharedSourceFolder = sourceFolderHelper.sourceFolder(ScoutTier.Shared)
+                op.serverSourceFolder = sourceFolderHelper.sourceFolder(ScoutTier.Server)
+                op.pageDataSourceFolder = sourceFolderHelper.generatedSourceFolder(ScoutTier.Shared) ?: sourceFolderHelper.sourceFolder(ScoutTier.Shared)
 
-                op.testSourceFolder = sourceFolderHelper.serverTestSourceFolder()
+                op.testSourceFolder = sourceFolderHelper.testSourceFolder(ScoutTier.Server)
 
-                sourceFolderHelper.clientSourceFolder()?.javaEnvironment()?.api(IScoutApi::class.java)?.ifPresent {
+                sourceFolderHelper.sourceFolder(ScoutTier.Client)?.javaEnvironment()?.api(IScoutApi::class.java)?.ifPresent {
                     op.superType = it.AbstractPageWithTable().fqn()
                 }
-                sourceFolderHelper.serverSourceFolder()?.javaEnvironment()?.api(IScoutApi::class.java)?.ifPresent {
+                sourceFolderHelper.sourceFolder(ScoutTier.Server)?.javaEnvironment()?.api(IScoutApi::class.java)?.ifPresent {
                     op.serverSession = it.IServerSession().fqn()
                 }
 
@@ -129,16 +129,16 @@ class ElementCreationManagerImplementor : ElementCreationManager {
                 op.`package` = sourceFolderHelper.tier()!!.convert(ScoutTier.Shared, pkg)
                 op.keyType = Long::class.javaObjectType.name
 
-                op.sharedSourceFolder = sourceFolderHelper.sharedSourceFolder()
-                op.serverSourceFolder = sourceFolderHelper.serverSourceFolder()
+                op.sharedSourceFolder = sourceFolderHelper.sourceFolder(ScoutTier.Shared)
+                op.serverSourceFolder = sourceFolderHelper.sourceFolder(ScoutTier.Server)
 
-                op.testSourceFolder = sourceFolderHelper.serverTestSourceFolder()
+                op.testSourceFolder = sourceFolderHelper.testSourceFolder(ScoutTier.Server)
 
-                sourceFolderHelper.sharedSourceFolder()?.javaEnvironment()?.api(IScoutApi::class.java)?.ifPresent {
+                sourceFolderHelper.sourceFolder(ScoutTier.Shared)?.javaEnvironment()?.api(IScoutApi::class.java)?.ifPresent {
                     op.superType = it.LookupCall().fqn()
                     op.lookupServiceSuperType = it.AbstractLookupService().fqn()
                 }
-                sourceFolderHelper.serverSourceFolder()?.javaEnvironment()?.api(IScoutApi::class.java)?.ifPresent {
+                sourceFolderHelper.sourceFolder(ScoutTier.Server)?.javaEnvironment()?.api(IScoutApi::class.java)?.ifPresent {
                     op.serverSession = it.IServerSession().fqn()
                 }
             })
@@ -156,9 +156,9 @@ class ElementCreationManagerImplementor : ElementCreationManager {
                 op.`package` = sourceFolderHelper.tier()!!.convert(ScoutTier.Shared, pkg)
                 op.codeTypeIdDataType = idDataType
 
-                op.sharedSourceFolder = sourceFolderHelper.sharedSourceFolder()
+                op.sharedSourceFolder = sourceFolderHelper.sourceFolder(ScoutTier.Shared)
 
-                sourceFolderHelper.sharedSourceFolder()?.javaEnvironment()?.api(IScoutApi::class.java)?.ifPresent {
+                sourceFolderHelper.sourceFolder(ScoutTier.Shared)?.javaEnvironment()?.api(IScoutApi::class.java)?.ifPresent {
                     op.superType = it.AbstractCodeType().fqn() + JavaTypes.C_GENERIC_START + idDataType + ", " + idDataType + JavaTypes.C_GENERIC_END
                 }
             })

--- a/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/lookupcall/CreateLookupCallAction.kt
+++ b/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/lookupcall/CreateLookupCallAction.kt
@@ -12,6 +12,7 @@ package org.eclipse.scout.sdk.s2i.lookupcall
 
 import com.intellij.psi.PsiClass
 import org.eclipse.scout.sdk.core.s.lookupcall.LookupCallNewOperation
+import org.eclipse.scout.sdk.core.s.util.ITier
 import org.eclipse.scout.sdk.core.s.util.ScoutTier
 import org.eclipse.scout.sdk.s2i.EclipseScoutBundle
 import org.eclipse.scout.sdk.s2i.element.CreateElementAction
@@ -20,7 +21,7 @@ import org.eclipse.scout.sdk.s2i.toIdea
 
 class CreateLookupCallAction : CreateElementAction<LookupCallNewOperation>(EclipseScoutBundle.message("create.lookupcall"), EclipseScoutBundle.message("create.lookupcall.desc")) {
 
-    override fun startScoutTiers(): Collection<ScoutTier> = listOf(ScoutTier.Shared, ScoutTier.Server)
+    override fun startTiers(): Collection<ITier<*>> = listOf(ScoutTier.Shared, ScoutTier.Server)
 
     override fun operationClass(): Class<LookupCallNewOperation> = LookupCallNewOperation::class.java
 

--- a/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/util/S2iTier.kt
+++ b/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/util/S2iTier.kt
@@ -11,12 +11,21 @@
 package org.eclipse.scout.sdk.s2i.util
 
 import com.intellij.openapi.module.Module
-import org.eclipse.scout.sdk.core.s.util.ScoutTier
+import org.eclipse.scout.sdk.core.apidef.IApiSpecification
+import org.eclipse.scout.sdk.core.s.util.ITier
+import org.eclipse.scout.sdk.core.apidef.OptApiFunction
 import org.eclipse.scout.sdk.s2i.environment.IdeaEnvironment
 import org.eclipse.scout.sdk.s2i.findTypeByName
+import java.util.*
 
-class S2iScoutTier {
+class S2iTier {
     companion object {
-        fun valueOf(module: Module, environment: IdeaEnvironment? = null): ScoutTier? = ScoutTier.valueOf({ module.findTypeByName(it) != null }, ApiHelper.scoutApiFor(module, environment)).orElse(null)
+        fun of(module: Module, environment: IdeaEnvironment? = null): ITier<*>? = ITier.of({ module.findTypeByName(it) != null },
+            object : OptApiFunction {
+                override fun <T : IApiSpecification> apply(c: Class<T>): Optional<T> {
+                    return Optional.ofNullable(ApiHelper.apiFor(module, c, environment))
+                }
+            })
+            .orElse(null)
     }
 }

--- a/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/util/SourceFolderHelper.kt
+++ b/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/util/SourceFolderHelper.kt
@@ -17,211 +17,324 @@ import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.roots.SourceFolder
 import com.intellij.openapi.vfs.VirtualFile
+import com.jetbrains.rd.util.first
 import org.eclipse.scout.sdk.core.ISourceFolders
 import org.eclipse.scout.sdk.core.model.api.IClasspathEntry
 import org.eclipse.scout.sdk.core.s.IScoutSourceFolders
-import org.eclipse.scout.sdk.core.s.util.ScoutTier
+import org.eclipse.scout.sdk.core.s.util.ITier
+import org.eclipse.scout.sdk.core.s.util.TierTree
 import org.eclipse.scout.sdk.core.util.FinalValue
 import org.eclipse.scout.sdk.core.util.Strings
 import org.jetbrains.jps.model.java.JavaSourceRootType
+import java.util.*
 
-class SourceFolderHelper(val project: Project, val sourceFolder: SourceFolder, val scoutTierOfModule: (Module) -> ScoutTier? = { S2iScoutTier.valueOf(it) }, val findClasspathEntry: (VirtualFile?) -> IClasspathEntry?) {
+class SourceFolderHelper(val project: Project, val sourceFolder: SourceFolder, tierOfModule: ((Module) -> ITier<*>?)? = null, val findClasspathEntry: (VirtualFile?) -> IClasspathEntry?) {
 
+    private val m_sourceFolderHelperInfo = SourceFolderHelperInfo(project, sourceFolder, tierOfModule(tierOfModule), findClasspathEntry)
+
+    private val m_tier = FinalValue<ITier<*>?>()
     private val m_classpathEntry = FinalValue<IClasspathEntry?>()
 
-    private val m_tier = FinalValue<ScoutTier?>()
-
-    private val m_clientSourceFolderPair = FinalValue<Pair<SourceFolder, IClasspathEntry>?>()
-    private val m_sharedSourceFolderPair = FinalValue<Pair<SourceFolder, IClasspathEntry>?>()
-    private val m_serverSourceFolderPair = FinalValue<Pair<SourceFolder, IClasspathEntry>?>()
-
-    private val m_sharedGeneratedSourceFolder = FinalValue<IClasspathEntry?>()
-
-    private val m_clientTestSourceFolderPair = FinalValue<Pair<SourceFolder, IClasspathEntry>?>()
-    private val m_sharedTestSourceFolderPair = FinalValue<Pair<SourceFolder, IClasspathEntry>?>()
-    private val m_serverTestSourceFolderPair = FinalValue<Pair<SourceFolder, IClasspathEntry>?>()
-
-    private val m_clientMainTestSourceFolder = FinalValue<IClasspathEntry?>()
-    private val m_sharedMainTestSourceFolder = FinalValue<IClasspathEntry?>()
-    private val m_serverMainTestSourceFolder = FinalValue<IClasspathEntry?>()
+    private val m_tierSourceFolderBundleMap = HashMap<ITier<*>?, SourceFolderBundle?>()
+    private val m_moduleTierMap = HashMap<Module, ITier<*>?>()
 
     companion object {
         /**
-         * Finds the closest dependency pair of [SourceFolder] and [IClasspathEntry] to the given [sourceFolder]. See [findClosestSourceFolder].
+         * Finds the closest dependency pair of [SourceFolder] and [IClasspathEntry] to the given [sourceFolder].
          */
         fun findClosestSourceFolderDependency(
-            project: Project,
-            scoutTier: ScoutTier,
-            test: Boolean,
             sourceFolder: SourceFolder,
-            scoutTierOfModule: ((Module) -> ScoutTier?)? = null,
+            tier: ITier<*>,
+            test: Boolean,
+            project: Project,
+            tierOfModule: (Module) -> ITier<*>?,
             findClasspathEntry: (VirtualFile?) -> IClasspathEntry?
+        ): Pair<SourceFolder, IClasspathEntry>? {
+            val module = sourceFolder.contentEntry.rootModel.module
+            val tierSourceFolderBundle = tierOfModule(module)?.let { t ->
+                val sourceFolderHelperInfo = SourceFolderHelperInfo(project, sourceFolder, tierOfModule, findClasspathEntry)
+                DependencySourceFolderBundle(tier, StartSourceFolderBundle(t, sourceFolderHelperInfo), sourceFolderHelperInfo)
+            } ?: return null
+            return if (test) tierSourceFolderBundle.testSourceFolderPair() else tierSourceFolderBundle.sourceFolderPair()
+        }
+
+        /**
+         * Finds the closest dependency pair of [SourceFolder] and [IClasspathEntry] to the given [sourceFolder].
+         */
+        fun findClosestDependentSourceFolder(
+            sourceFolder: SourceFolder,
+            tier: ITier<*>,
+            test: Boolean,
+            project: Project,
+            tierOfModule: (Module) -> ITier<*>?,
+            findClasspathEntry: (VirtualFile?) -> IClasspathEntry?
+        ): Pair<SourceFolder, IClasspathEntry>? {
+            val module = sourceFolder.contentEntry.rootModel.module
+            val tierSourceFolderBundle = tierOfModule(module)?.let { t ->
+                val sourceFolderHelperInfo = SourceFolderHelperInfo(project, sourceFolder, tierOfModule, findClasspathEntry)
+                DependentSourceFolderBundle(tier, StartSourceFolderBundle(t, sourceFolderHelperInfo), sourceFolderHelperInfo)
+            } ?: return null
+            return if (test) tierSourceFolderBundle.testSourceFolderPair() else tierSourceFolderBundle.sourceFolderPair()
+        }
+
+        private fun Module.getTier(tierOfModule: (Module) -> ITier<*>?): ITier<*>? {
+            return tierOfModule(this)
+        }
+    }
+
+    private fun tierOfModule(tierOfModule: ((Module) -> ITier<*>?)?): (Module) -> ITier<*>? = { module -> m_moduleTierMap.computeIfAbsent(module, tierOfModule ?: { S2iTier.of(it) }) }
+
+    fun tier(): ITier<*>? = m_tier.computeIfAbsentAndGet {
+        sourceFolder.contentEntry.rootModel.module.getTier(m_sourceFolderHelperInfo.tierOfModule)
+    }
+
+    fun classpathEntry(): IClasspathEntry? = m_classpathEntry.computeIfAbsentAndGet {
+        findClasspathEntry(sourceFolder.file)
+    }
+
+    fun sourceFolder(tier: ITier<*>): IClasspathEntry? = sourceFolderBundle(tier)?.sourceFolderPair()?.second
+
+    fun testSourceFolder(tier: ITier<*>): IClasspathEntry? = sourceFolderBundle(tier)?.testSourceFolderPair()?.second
+
+    fun mainTestSourceFolder(tier: ITier<*>): IClasspathEntry? = sourceFolderBundle(tier)?.mainTestSourceFolder()
+
+    fun generatedSourceFolder(tier: ITier<*>): IClasspathEntry? = sourceFolderBundle(tier)?.generatedSourceFolder()
+
+    private fun sourceFolderBundle(tier: ITier<*>): SourceFolderBundle? {
+        // add start sourceFolderBundle
+        m_tierSourceFolderBundleMap.computeIfAbsent(tier()) {
+            it?.let { t -> StartSourceFolderBundle(t, m_sourceFolderHelperInfo) }
+        }
+        if (m_tierSourceFolderBundleMap.isEmpty()) {
+            return null
+        }
+
+        m_tierSourceFolderBundleMap[tier]?.let { return it }
+
+        // consider a tree like this, uppercase letters represent nodes for whom we already computed the sourceFolderBundle
+        //
+        //    a <- root
+        //   b
+        //  c d
+        // E   f <- example 1
+        //  G
+        //   h
+        //    i <- example 2
+
+        // example 1
+        // search for node f, which is not a descendant of any node for whom we already computed the sourceFolderBundle
+        // -> we need to compute some ancestors first before we can compute the descendants down to f (after all necessary descendants are computed this example is equivalent to example 2)
+
+        // example 2
+        // search for node i, which is a descendant of at least one node for whom we already computed the sourceFolderBundle
+        // -> we just need to compute some more descendants
+
+        // get a path (start inclusive, end exclusive) from the root node to the first node for whom we already computed the sourceFolderBundle
+
+        // example 1 & 2: E
+        var existingTier: ITier<*>? = null
+        // example 1 & 2: a > b > c
+        val pathToExistingTier = TierTree.topDownPath(null, m_tierSourceFolderBundleMap.first().key)
+            .takeWhile { t ->
+                existingTier = t
+                return@takeWhile !m_tierSourceFolderBundleMap.containsKey(t)
+            }
+
+        // get a path (start exclusive, end inclusive) from the last node for whom we already computed the sourceFolderBundle or that is contained in the path we just created to the node we search for
+
+        // example 1: b
+        // example 2: G
+        var startTier: ITier<*>? = null
+        // example 1: d > f
+        // example 2: h > i
+        val pathToTier = TierTree.topDownPath(null, tier).reversed()
+            .takeWhile { t ->
+                startTier = t
+                return@takeWhile !m_tierSourceFolderBundleMap.containsKey(t) && !pathToExistingTier.contains(t)
+            }
+            .reversed()
+
+        if (pathToExistingTier.contains(startTier)) {
+            // we need to compute sourceFolderBundles for all elements from the end of pathToExistingTier until startTier
+            (pathToExistingTier.size - 1 downTo pathToExistingTier.lastIndexOf(startTier))
+                .map { pathToExistingTier[it] } // example 1: c > b
+                .forEach {
+                    // compute a sourceFolderBundle as dependency of existingTier and update existingTier
+                    m_tierSourceFolderBundleMap[it] = DependencySourceFolderBundle(it, m_tierSourceFolderBundleMap[existingTier], m_sourceFolderHelperInfo)
+                    existingTier = it
+
+                    // example 1: first compute C as ancestor of E, then compute B as ancestor of C
+                    // after this the tree looks like this
+                    //
+                    //    a
+                    //   B
+                    //  C d
+                    // E   f
+                    //  G
+                    //   h
+                    //    i
+                }
+        }
+
+        if (!m_tierSourceFolderBundleMap.containsKey(startTier)) {
+            return null
+        }
+
+        // compute sourceFolderBundles for all elements from startTier to the tier we search for
+        pathToTier.forEach {
+            // compute a sourceFolderBundle as dependency of startTier and update startTier
+            m_tierSourceFolderBundleMap[it] = DependentSourceFolderBundle(it, m_tierSourceFolderBundleMap[startTier], m_sourceFolderHelperInfo)
+            startTier = it
+
+            // example 1: first compute D as descendant of B, then compute F as descendant of D
+            // after this the tree looks like this
+            //
+            //    a
+            //   B
+            //  C D
+            // E   F
+            //  G
+            //   h
+            //    i
+
+            // example 2: first compute H as descendant of G, then compute I as descendant of I
+            // after this the tree looks like this
+            //
+            //    a
+            //   b
+            //  c d
+            // E   f
+            //  G
+            //   H
+            //    I
+        }
+
+        return m_tierSourceFolderBundleMap[tier]
+    }
+
+    private data class SourceFolderHelperInfo(val project: Project, val sourceFolder: SourceFolder, val tierOfModule: (Module) -> ITier<*>?, val findClasspathEntry: (VirtualFile?) -> IClasspathEntry?)
+
+    private abstract class SourceFolderBundle(val tier: ITier<*>, val referenceSourceFolderBundle: SourceFolderBundle?, val sourceFolderHelperInfo: SourceFolderHelperInfo) {
+        private val m_sourceFolderPair = FinalValue<Pair<SourceFolder, IClasspathEntry>?>()
+        private val m_testSourceFolderPair = FinalValue<Pair<SourceFolder, IClasspathEntry>?>()
+        private val m_mainTestSourceFolder = FinalValue<IClasspathEntry?>()
+        private val m_generatedSourceFolder = FinalValue<IClasspathEntry?>()
+
+        protected abstract fun computeSourceFolderPair(): Pair<SourceFolder, IClasspathEntry>?
+
+        fun sourceFolderPair() = m_sourceFolderPair.computeIfAbsentAndGet { computeSourceFolderPair() }
+
+        fun testSourceFolderPair() = m_testSourceFolderPair.computeIfAbsentAndGet {
+            findTestSourceFolderPair()
+        }
+
+        fun mainTestSourceFolder() = m_mainTestSourceFolder.computeIfAbsentAndGet {
+            findMainSourceFolder(testSourceFolderPair()?.first)?.file?.let { return@computeIfAbsentAndGet sourceFolderHelperInfo.findClasspathEntry(it) }
+        }
+
+        fun generatedSourceFolder() = m_generatedSourceFolder.computeIfAbsentAndGet {
+            findGeneratedSourceFolder(sourceFolderPair()?.first)?.file?.let { return@computeIfAbsentAndGet sourceFolderHelperInfo.findClasspathEntry(it) }
+        }
+
+        /**
+         * Finds the closest dependency pair of [SourceFolder] and [IClasspathEntry] to the given [sourceFolder]. See [findClosestSourceFolder].
+         */
+        protected fun findClosestSourceFolderDependency(
+            sourceFolder: SourceFolder,
+            test: Boolean
         ): Pair<SourceFolder, IClasspathEntry>? {
             val module = sourceFolder.contentEntry.rootModel.module
             val dependencies = ModuleRootManager.getInstance(module).dependencies
 
-            return findClosestSourceFolder(project, scoutTier, test, module, dependencies.asSequence(), scoutTierOfModule, findClasspathEntry)
+            return findClosestSourceFolder(module, dependencies.asSequence(), test)
         }
 
         /**
          * Finds the closest dependency pair of [SourceFolder] and [IClasspathEntry] to the given [sourceFolder]. See [findClosestSourceFolder].
          */
-        fun findClosestDependentSourceFolder(
-            project: Project,
-            scoutTier: ScoutTier,
-            test: Boolean,
+        protected fun findClosestDependentSourceFolder(
             sourceFolder: SourceFolder,
-            scoutTierOfModule: ((Module) -> ScoutTier?)? = null,
-            findClasspathEntry: (VirtualFile?) -> IClasspathEntry?
+            test: Boolean
         ): Pair<SourceFolder, IClasspathEntry>? {
             val module = sourceFolder.contentEntry.rootModel.module
-            val dependentModules = ModuleManager.getInstance(project).getModuleDependentModules(module)
+            val dependentModules = ModuleManager.getInstance(sourceFolderHelperInfo.project).getModuleDependentModules(module)
 
-            return findClosestSourceFolder(project, scoutTier, test, module, dependentModules.asSequence(), scoutTierOfModule, findClasspathEntry)
+            return findClosestSourceFolder(module, dependentModules.asSequence(), test)
         }
+
 
         /**
          * Finds the closest pair of [SourceFolder] and [IClasspathEntry] to the given [reference] in the given [modules] that match the following restrictions:
-         * @param scoutTier which [ScoutTier] to look for
          * @param test weather to look for test source folders or not
          */
-        fun findClosestSourceFolder(
-            project: Project,
-            scoutTier: ScoutTier,
-            test: Boolean,
+        private fun findClosestSourceFolder(
             reference: Module,
             modules: Sequence<Module>,
-            scoutTierOfModule: ((Module) -> ScoutTier?)? = null,
-            findClasspathEntry: (VirtualFile?) -> IClasspathEntry?
+            test: Boolean
         ): Pair<SourceFolder, IClasspathEntry>? {
-            val fileIndex = ProjectFileIndex.getInstance(project)
-            val myScoutTierOfModule = scoutTierOfModule ?: { S2iScoutTier.valueOf(it) }
+            val fileIndex = ProjectFileIndex.getInstance(sourceFolderHelperInfo.project)
 
-            val sourceFolder = modules
+            val lookupName = reference.getTier(sourceFolderHelperInfo.tierOfModule)?.convert(tier, reference.name) ?: reference.name
+
+            val sourceFoldersSorted = modules
                 .flatMap {
                     ModuleRootManager.getInstance(it).sourceRoots.asSequence()
                 }
                 .mapNotNull { fileIndex.getSourceFolder(it) }
                 .filter { it.rootType is JavaSourceRootType && it.isTestSource == test }
                 .filter { !isGeneratedSourceFolder(it) }
-                .map { it to Strings.levenshteinDistance(it.contentEntry.rootModel.module.name, reference.name) }
+                .map { it to Strings.levenshteinDistance(it.contentEntry.rootModel.module.name, lookupName) }
                 .sortedBy { it.second }
-                .firstOrNull { (sf, _) -> myScoutTierOfModule(sf.contentEntry.rootModel.module) == scoutTier }?.first ?: return null
+                .map { it.first }
+                .toList()
+            val sourceFolder = sourceFoldersSorted.firstOrNull { isTier(it) } ?: sourceFoldersSorted.firstOrNull { isTierIncludedIn(it) } ?: return null
 
-            return findClasspathEntry(sourceFolder.file)?.let { sourceFolder to it }
+            return sourceFolderHelperInfo.findClasspathEntry(sourceFolder.file)?.let { sourceFolder to it }
         }
 
+        private fun isTier(sourceFolder: SourceFolder): Boolean = tier == sourceFolder.contentEntry.rootModel.module.getTier(sourceFolderHelperInfo.tierOfModule)
+
+        private fun isTierIncludedIn(sourceFolder: SourceFolder): Boolean = tier.isIncludedIn(sourceFolder.contentEntry.rootModel.module.getTier(sourceFolderHelperInfo.tierOfModule))
+
         /**
-         * Finds the closest pair of [SourceFolder] and [IClasspathEntry] in the given [project] that is a [ScoutTier.Client] for the given [sharedSourceFolder].
+         * Finds the closest test pair of [SourceFolder] and [IClasspathEntry] in the given [project] that is a [ITier] for the given [sourceFolder].
          */
-        fun findClientSourceFolderPair(project: Project, sharedSourceFolder: SourceFolder?, scoutTierOfModule: ((Module) -> ScoutTier?)? = null, findClasspathEntry: (VirtualFile?) -> IClasspathEntry?): Pair<SourceFolder, IClasspathEntry>? {
-            if (sharedSourceFolder == null) {
-                return null
+        private fun findTestSourceFolderPair(): Pair<SourceFolder, IClasspathEntry>? {
+            val sourceFolder = sourceFolderPair()?.first ?: return null
+            if (isTierIncludedIn(sourceFolder)) {
+                findTestSourceFolder(sourceFolder)?.let { sf -> sourceFolderHelperInfo.findClasspathEntry(sf.file)?.let { sf to it } }?.let { return it }
             }
-            return findClosestDependentSourceFolder(project, ScoutTier.Client, false, sharedSourceFolder, scoutTierOfModule, findClasspathEntry)
+            return findClosestDependentSourceFolder(sourceFolder, true)
         }
-
-        /**
-         * Finds the closest pair of [SourceFolder] and [IClasspathEntry] in the given [project] that is a [ScoutTier.Shared] for the given [clientOrServerSourceFolder].
-         */
-        fun findSharedSourceFolderPair(
-            project: Project,
-            clientOrServerSourceFolder: SourceFolder?,
-            scoutTierOfModule: ((Module) -> ScoutTier?)? = null,
-            findClasspathEntry: (VirtualFile?) -> IClasspathEntry?
-        ): Pair<SourceFolder, IClasspathEntry>? {
-            if (clientOrServerSourceFolder == null) {
-                return null
-            }
-            return findClosestSourceFolderDependency(project, ScoutTier.Shared, false, clientOrServerSourceFolder, scoutTierOfModule, findClasspathEntry)
-        }
-
-        /**
-         * Finds the closest pair of [SourceFolder] and [IClasspathEntry] in the given [project] that is a [ScoutTier.Server] for the given [sharedSourceFolder].
-         */
-        fun findServerSourceFolderPair(project: Project, sharedSourceFolder: SourceFolder?, scoutTierOfModule: ((Module) -> ScoutTier?)? = null, findClasspathEntry: (VirtualFile?) -> IClasspathEntry?): Pair<SourceFolder, IClasspathEntry>? {
-            if (sharedSourceFolder == null) {
-                return null
-            }
-            return findClosestDependentSourceFolder(project, ScoutTier.Server, false, sharedSourceFolder, scoutTierOfModule, findClasspathEntry)
-        }
-
-        /**
-         * Finds the closest test pair of [SourceFolder] and [IClasspathEntry] in the given [project] that is a [scoutTier] for the given [sourceFolder].
-         */
-        fun findTestSourceFolderPair(
-            project: Project,
-            scoutTier: ScoutTier,
-            sourceFolder: SourceFolder?,
-            scoutTierOfModule: ((Module) -> ScoutTier?)? = null,
-            findClasspathEntry: (VirtualFile?) -> IClasspathEntry?
-        ): Pair<SourceFolder, IClasspathEntry>? {
-            if (sourceFolder == null) {
-                return null
-            }
-            val myScoutTierOfModule = scoutTierOfModule ?: { S2iScoutTier.valueOf(it) }
-            if (myScoutTierOfModule(sourceFolder.contentEntry.rootModel.module) == scoutTier) {
-                findTestSourceFolderPair(sourceFolder)?.let { findClasspathEntry(it.file) }?.let { return sourceFolder to it }
-            }
-            return findClosestDependentSourceFolder(project, scoutTier, true, sourceFolder, scoutTierOfModule, findClasspathEntry)
-        }
-
-        /**
-         * Finds the closest test pair of [SourceFolder] and [IClasspathEntry] in the given [project] that is a [ScoutTier.Client] for the given [clientSourceFolder].
-         */
-        fun findClientTestSourceFolderPair(
-            project: Project,
-            clientSourceFolder: SourceFolder?,
-            scoutTierOfModule: ((Module) -> ScoutTier?)? = null,
-            findClasspathEntry: (VirtualFile?) -> IClasspathEntry?
-        ): Pair<SourceFolder, IClasspathEntry>? {
-            return findTestSourceFolderPair(project, ScoutTier.Client, clientSourceFolder, scoutTierOfModule, findClasspathEntry)
-        }
-
-        /**
-         * Finds the closest test pair of [SourceFolder] and [IClasspathEntry] in the given [project] that is a [ScoutTier.Shared] for the given [sharedSourceFolder].
-         */
-        fun findSharedTestSourceFolderPair(
-            project: Project,
-            sharedSourceFolder: SourceFolder?,
-            scoutTierOfModule: ((Module) -> ScoutTier?)? = null,
-            findClasspathEntry: (VirtualFile?) -> IClasspathEntry?
-        ): Pair<SourceFolder, IClasspathEntry>? {
-            return findTestSourceFolderPair(project, ScoutTier.Shared, sharedSourceFolder, scoutTierOfModule, findClasspathEntry)
-        }
-
-        /**
-         * Finds the closest test pair of [SourceFolder] and [IClasspathEntry] in the given [project] that is a [ScoutTier.Server] for the given [serverSourceFolder].
-         */
-        fun findServerTestSourceFolderPair(
-            project: Project,
-            serverSourceFolder: SourceFolder?,
-            scoutTierOfModule: ((Module) -> ScoutTier?)? = null,
-            findClasspathEntry: (VirtualFile?) -> IClasspathEntry?
-        ): Pair<SourceFolder, IClasspathEntry>? {
-            return findTestSourceFolderPair(project, ScoutTier.Server, serverSourceFolder, scoutTierOfModule, findClasspathEntry)
-        }
-
-        /**
-         * Finds the src/main/java [SourceFolder] for the given [sourceFolder].
-         */
-        fun findMainSourceFolder(sourceFolder: SourceFolder?): SourceFolder? = findSourceFolder(sourceFolder) { isMainSourceFolder(it) }
-
-        fun isMainSourceFolder(sourceFolder: SourceFolder?): Boolean = sourceFolderEndsWith(sourceFolder, ISourceFolders.MAIN_JAVA_SOURCE_FOLDER) && sourceFolder?.rootType is JavaSourceRootType && !sourceFolder.isTestSource
-
-        /**
-         * Finds the src/generated/java [SourceFolder] for the given [sourceFolder].
-         */
-        fun findGeneratedSourceFolder(sourceFolder: SourceFolder?): SourceFolder? = findSourceFolder(sourceFolder) { isGeneratedSourceFolder(it) }
-
-        fun isGeneratedSourceFolder(sourceFolder: SourceFolder?): Boolean = sourceFolderEndsWith(sourceFolder, IScoutSourceFolders.GENERATED_SOURCE_FOLDER) && sourceFolder?.rootType is JavaSourceRootType && !sourceFolder.isTestSource
 
         /**
          * Finds the src/test/java [SourceFolder] for the given [sourceFolder].
          */
-        fun findTestSourceFolderPair(sourceFolder: SourceFolder?): SourceFolder? = findSourceFolder(sourceFolder) { isTestSourceFolder(it) }
+        private fun findTestSourceFolder(sourceFolder: SourceFolder?): SourceFolder? = findSourceFolder(sourceFolder) { isTestSourceFolder(it) }
 
-        fun isTestSourceFolder(sourceFolder: SourceFolder?): Boolean = sourceFolderEndsWith(sourceFolder, ISourceFolders.TEST_JAVA_SOURCE_FOLDER) && sourceFolder?.rootType is JavaSourceRootType && sourceFolder.isTestSource
+        /**
+         * Finds the src/main/java [SourceFolder] for the given [sourceFolder].
+         */
+        protected fun findMainSourceFolder(sourceFolder: SourceFolder?): SourceFolder? = findSourceFolder(sourceFolder) { isMainSourceFolder(it) }
+
+        /**
+         * Finds the src/generated/java [SourceFolder] for the given [sourceFolder].
+         */
+        private fun findGeneratedSourceFolder(sourceFolder: SourceFolder?): SourceFolder? = findSourceFolder(sourceFolder) { isGeneratedSourceFolder(it) }
+
+        private fun isTestSourceFolder(sourceFolder: SourceFolder?): Boolean = sourceFolderEndsWith(sourceFolder, ISourceFolders.TEST_JAVA_SOURCE_FOLDER) && sourceFolder?.rootType is JavaSourceRootType && sourceFolder.isTestSource
+
+        private fun isMainSourceFolder(sourceFolder: SourceFolder?): Boolean = sourceFolderEndsWith(sourceFolder, ISourceFolders.MAIN_JAVA_SOURCE_FOLDER) && sourceFolder?.rootType is JavaSourceRootType && !sourceFolder.isTestSource
+
+        private fun isGeneratedSourceFolder(sourceFolder: SourceFolder?): Boolean =
+            sourceFolderEndsWith(sourceFolder, IScoutSourceFolders.GENERATED_SOURCE_FOLDER) && sourceFolder?.rootType is JavaSourceRootType && !sourceFolder.isTestSource
+
+        private fun sourceFolderEndsWith(sourceFolder: SourceFolder?, suffix: String): Boolean {
+            if (sourceFolder == null) {
+                return false
+            }
+            return sourceFolder.file?.path?.endsWith(suffix) ?: false
+        }
 
         /**
          * Finds the [SourceFolder] that matches the given [sourceFolderCondition] in the module of the given [sourceFolder].
@@ -239,90 +352,25 @@ class SourceFolderHelper(val project: Project, val sourceFolder: SourceFolder, v
             val sourceRoots = ModuleRootManager.getInstance(module)?.sourceRoots ?: return null
 
             return sourceRoots.asSequence()
-                .map { fileIndex.getSourceFolder(it) }
-                .filterNotNull()
+                .mapNotNull { fileIndex.getSourceFolder(it) }
                 .firstOrNull { sourceFolderCondition(it) }
         }
+    }
 
-        private fun sourceFolderEndsWith(sourceFolder: SourceFolder?, suffix: String): Boolean {
-            if (sourceFolder == null) {
-                return false
-            }
-            return sourceFolder.file?.path?.endsWith(suffix) ?: false
+    private class DependentSourceFolderBundle(tier: ITier<*>, referenceSourceFolderBundle: SourceFolderBundle?, sourceFolderHelperInfo: SourceFolderHelperInfo) :
+        SourceFolderBundle(tier, referenceSourceFolderBundle, sourceFolderHelperInfo) {
+        override fun computeSourceFolderPair(): Pair<SourceFolder, IClasspathEntry>? = referenceSourceFolderBundle?.sourceFolderPair()?.first?.let { sf -> findClosestDependentSourceFolder(sf, false) }
+    }
+
+    private class DependencySourceFolderBundle(tier: ITier<*>, referenceSourceFolderBundle: SourceFolderBundle?, sourceFolderHelperInfo: SourceFolderHelperInfo) :
+        SourceFolderBundle(tier, referenceSourceFolderBundle, sourceFolderHelperInfo) {
+        override fun computeSourceFolderPair(): Pair<SourceFolder, IClasspathEntry>? = referenceSourceFolderBundle?.sourceFolderPair()?.first?.let { sf -> findClosestSourceFolderDependency(sf, false) }
+    }
+
+    private class StartSourceFolderBundle(tier: ITier<*>, sourceFolderHelperInfo: SourceFolderHelperInfo) : SourceFolderBundle(tier, null, sourceFolderHelperInfo) {
+        override fun computeSourceFolderPair(): Pair<SourceFolder, IClasspathEntry>? {
+            val mainSourceFolder = findMainSourceFolder(sourceFolderHelperInfo.sourceFolder) ?: return null
+            return sourceFolderHelperInfo.findClasspathEntry(mainSourceFolder.file)?.let { mainSourceFolder to it }
         }
-    }
-
-    fun classpathEntry(): IClasspathEntry? = m_classpathEntry.computeIfAbsentAndGet {
-        findClasspathEntry(sourceFolder.file)
-    }
-
-    fun tier(): ScoutTier? = m_tier.computeIfAbsentAndGet {
-        scoutTierOfModule(sourceFolder.contentEntry.rootModel.module)
-    }
-
-    fun clientSourceFolder(): IClasspathEntry? = clientSourceFolderPair()?.second
-
-    private fun clientSourceFolderPair(): Pair<SourceFolder, IClasspathEntry>? = m_clientSourceFolderPair.computeIfAbsentAndGet {
-        if (tier() == ScoutTier.Client) {
-            return@computeIfAbsentAndGet mainSourceFolderPair()
-        }
-        return@computeIfAbsentAndGet findClientSourceFolderPair(project, sharedSourceFolderPair()?.first, scoutTierOfModule, findClasspathEntry)
-    }
-
-    fun sharedSourceFolder(): IClasspathEntry? = sharedSourceFolderPair()?.second
-
-    private fun sharedSourceFolderPair(): Pair<SourceFolder, IClasspathEntry>? = m_sharedSourceFolderPair.computeIfAbsentAndGet {
-        if (tier() == ScoutTier.Shared) {
-            return@computeIfAbsentAndGet mainSourceFolderPair()
-        }
-        return@computeIfAbsentAndGet findSharedSourceFolderPair(project, sourceFolder, scoutTierOfModule, findClasspathEntry)
-    }
-
-    fun serverSourceFolder(): IClasspathEntry? = serverSourceFolderPair()?.second
-
-    private fun serverSourceFolderPair(): Pair<SourceFolder, IClasspathEntry>? = m_serverSourceFolderPair.computeIfAbsentAndGet {
-        if (tier() == ScoutTier.Server) {
-            return@computeIfAbsentAndGet mainSourceFolderPair()
-        }
-        return@computeIfAbsentAndGet findServerSourceFolderPair(project, sharedSourceFolderPair()?.first, scoutTierOfModule, findClasspathEntry)
-    }
-
-    private fun mainSourceFolderPair(): Pair<SourceFolder, IClasspathEntry>? {
-        val mainSourceFolder = findMainSourceFolder(sourceFolder) ?: return null
-        return findClasspathEntry(mainSourceFolder.file)?.let { mainSourceFolder to it }
-    }
-
-    fun sharedGeneratedSourceFolder(): IClasspathEntry? = m_sharedGeneratedSourceFolder.computeIfAbsentAndGet {
-        findGeneratedSourceFolder(sharedSourceFolderPair()?.first)?.file?.let { return@computeIfAbsentAndGet findClasspathEntry(it) }
-    }
-
-    fun clientTestSourceFolder(): IClasspathEntry? = clientTestSourceFolderPair()?.second
-
-    private fun clientTestSourceFolderPair(): Pair<SourceFolder, IClasspathEntry>? = m_clientTestSourceFolderPair.computeIfAbsentAndGet {
-        findClientTestSourceFolderPair(project, clientSourceFolderPair()?.first, scoutTierOfModule, findClasspathEntry)
-    }
-
-    fun sharedTestSourceFolder(): IClasspathEntry? = sharedTestSourceFolderPair()?.second
-
-    private fun sharedTestSourceFolderPair(): Pair<SourceFolder, IClasspathEntry>? = m_sharedTestSourceFolderPair.computeIfAbsentAndGet {
-        findSharedTestSourceFolderPair(project, sharedSourceFolderPair()?.first, scoutTierOfModule, findClasspathEntry)
-    }
-
-    fun serverTestSourceFolder(): IClasspathEntry? = serverTestSourceFolderPair()?.second
-
-    private fun serverTestSourceFolderPair(): Pair<SourceFolder, IClasspathEntry>? = m_serverTestSourceFolderPair.computeIfAbsentAndGet {
-        findServerTestSourceFolderPair(project, serverSourceFolderPair()?.first, scoutTierOfModule, findClasspathEntry)
-    }
-
-    fun clientMainTestSourceFolder(): IClasspathEntry? = m_clientMainTestSourceFolder.computeIfAbsentAndGet {
-        findMainSourceFolder(clientTestSourceFolderPair()?.first)?.file?.let { return@computeIfAbsentAndGet findClasspathEntry(it) }
-    }
-
-    fun sharedMainTestSourceFolder(): IClasspathEntry? = m_sharedMainTestSourceFolder.computeIfAbsentAndGet {
-        findMainSourceFolder(sharedTestSourceFolderPair()?.first)?.file?.let { return@computeIfAbsentAndGet findClasspathEntry(it) }
-    }
-
-    fun serverMainTestSourceFolder(): IClasspathEntry? = m_serverMainTestSourceFolder.computeIfAbsentAndGet {
-        findMainSourceFolder(serverTestSourceFolderPair()?.first)?.file?.let { return@computeIfAbsentAndGet findClasspathEntry(it) }
     }
 }


### PR DESCRIPTION
Add a tree that represents the hierarchy of all tiers. This tree can
handle ITier's, therefore ScoutTier now implements ITier. The TierTree
provides the following methods
 - addDependency: add a direct dependency between two tiers
 - hasDependency: check if a tier has a direct or transitive dependency
   on another given tier
 - isAvailable: check if a tier equals another given tier or has a
   dependency on it
 - path: get the tier path from one tier to another
 - tierOf: as a tier is a Predicate<IJavaElement>, this method searches
   from the leaves to the root node for a matching ITier
The SourceFolderHelper now uses the TierTree to calculate all dependent
and dependency sourceFolders.
All hard coded dependency hierarchy between the ScoutTier was removed
and transferred to the TierTree in order to make the dependency
hierarchy easily extendable.