### PR TITLE
Use UTF-8 for Scout text properties (resource bundles)

### DIFF
--- a/org.eclipse.scout.sdk.core.s.test/src/test/java/org/eclipse/scout/sdk/core/s/nls/TranslationStoreSupplierExtension.java
+++ b/org.eclipse.scout.sdk.core.s.test/src/test/java/org/eclipse/scout/sdk/core/s/nls/TranslationStoreSupplierExtension.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -155,7 +156,7 @@ public class TranslationStoreSupplierExtension implements BeforeEachCallback, Af
         readOnlyProps.setProperty(TRANSLATION_KEY_1, KEY_1_VAL_OVERRIDDEN);
         var out = new ByteArrayOutputStream();
         readOnlyProps.store(out, "");
-        translationFiles.add(new ReadOnlyTranslationFile(() -> new ByteArrayInputStream(out.toByteArray()), Language.LANGUAGE_DEFAULT));
+        translationFiles.add(new ReadOnlyTranslationFile(() -> new ByteArrayInputStream(out.toByteArray()), StandardCharsets.UTF_8, Language.LANGUAGE_DEFAULT));
         when(txtSvc.order()).thenReturn(10000.0);
       }
       else {
@@ -180,7 +181,7 @@ public class TranslationStoreSupplierExtension implements BeforeEachCallback, Af
     }
 
     var language = parseLanguageFromFileName(file.getFileName().toString(), PROPERTIES_FILE_NAME_PREFIX).orElseThrow();
-    var props = new EditableTranslationFile(file, language);
+    var props = new EditableTranslationFile(file, StandardCharsets.UTF_8, language);
     assertTrue(props.load(new NullProgress()));
     return props;
   }

--- a/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/java/apidef/IScoutApi.java
+++ b/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/java/apidef/IScoutApi.java
@@ -10,6 +10,8 @@
 package org.eclipse.scout.sdk.core.s.java.apidef;
 
 
+import java.nio.charset.Charset;
+
 import org.eclipse.scout.sdk.core.java.apidef.IApiSpecification;
 
 public interface IScoutApi extends IApiSpecification, IScoutAnnotationApi, IScoutInterfaceApi, IScoutAbstractApi, IScoutExtensionApi, IScoutVariousApi {
@@ -24,4 +26,9 @@ public interface IScoutApi extends IApiSpecification, IScoutAnnotationApi, IScou
    * @return The supported Java major version (e.g. 8 or 11)
    */
   int[] supportedJavaVersions();
+
+  /**
+   * @return The {@link Charset} to use for reading and writing .properties files.
+   */
+  Charset propertiesEncoding();
 }

--- a/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/java/apidef/Scout10Api.java
+++ b/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/java/apidef/Scout10Api.java
@@ -9,6 +9,8 @@
  */
 package org.eclipse.scout.sdk.core.s.java.apidef;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
 import org.eclipse.scout.sdk.core.java.JavaTypes;
@@ -26,6 +28,11 @@ public interface Scout10Api extends IScoutApi {
   @Override
   default int[] supportedJavaVersions() {
     return new int[]{8, 11};
+  }
+
+  @Override
+  default Charset propertiesEncoding() {
+    return StandardCharsets.ISO_8859_1;
   }
 
   IScoutAnnotationApi.ApplicationScoped APPLICATION_SCOPED_ANNOTATION = new ApplicationScoped();

--- a/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/java/apidef/Scout232Api.java
+++ b/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/java/apidef/Scout232Api.java
@@ -9,6 +9,9 @@
  */
 package org.eclipse.scout.sdk.core.s.java.apidef;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
 import org.eclipse.scout.sdk.core.java.apidef.MaxApiLevel;
 
 @MaxApiLevel({23, 2})
@@ -27,5 +30,10 @@ public interface Scout232Api extends IScoutApi, IScoutChartApi, IScout22DoApi {
     public String fqn() {
       return "org.eclipse.scout.rt.nls.text.ScoutTextProviderService";
     }
+  }
+
+  @Override
+  default Charset propertiesEncoding() {
+    return StandardCharsets.UTF_8;
   }
 }

--- a/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/nls/properties/EditableTranslationFile.java
+++ b/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/nls/properties/EditableTranslationFile.java
@@ -15,6 +15,7 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -36,8 +37,8 @@ public class EditableTranslationFile extends AbstractTranslationPropertiesFile {
   private final Path m_file;
 
   @SuppressWarnings("findbugs:NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
-  public EditableTranslationFile(Path file, Language language) {
-    super(language, () -> toStream(file));
+  public EditableTranslationFile(Path file, Charset encoding, Language language) {
+    super(language, encoding, () -> toStream(file));
     m_file = Ensure.notNull(file);
   }
 

--- a/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/nls/properties/ITranslationPropertiesFile.java
+++ b/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/nls/properties/ITranslationPropertiesFile.java
@@ -9,6 +9,7 @@
  */
 package org.eclipse.scout.sdk.core.s.nls.properties;
 
+import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -49,6 +50,11 @@ public interface ITranslationPropertiesFile {
    * @return {@code true} if the operation changed entries. {@code false} if it is the same as before.
    */
   boolean load(IProgress progress);
+
+  /**
+   * @return The encoding of the .properties file.
+   */
+  Optional<Charset> encoding();
 
   /**
    * @return A {@link Stream} with all keys that exist in this {@code .properties} file.

--- a/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/nls/properties/PropertiesTranslationStore.java
+++ b/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/nls/properties/PropertiesTranslationStore.java
@@ -13,6 +13,7 @@ import static java.util.Collections.unmodifiableMap;
 import static org.eclipse.scout.sdk.core.s.nls.properties.AbstractTranslationPropertiesFile.getPropertiesFileName;
 import static org.eclipse.scout.sdk.core.util.Ensure.newFail;
 
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -26,6 +27,7 @@ import org.eclipse.scout.sdk.core.log.SdkLog;
 import org.eclipse.scout.sdk.core.s.environment.IEnvironment;
 import org.eclipse.scout.sdk.core.s.environment.IProgress;
 import org.eclipse.scout.sdk.core.s.environment.NullProgress;
+import org.eclipse.scout.sdk.core.s.java.apidef.IScoutApi;
 import org.eclipse.scout.sdk.core.s.nls.IEditableTranslationStore;
 import org.eclipse.scout.sdk.core.s.nls.ITranslation;
 import org.eclipse.scout.sdk.core.s.nls.ITranslationEntry;
@@ -42,6 +44,7 @@ import org.eclipse.scout.sdk.core.util.Ensure;
 public class PropertiesTranslationStore implements IEditableTranslationStore {
 
   private final PropertiesTextProviderService m_svc;
+  private final Charset m_encoding;
   private final Map<String, TranslationEntry> m_translations;
   private final Map<Language, ITranslationPropertiesFile> m_files;
   private final Set<ITranslationPropertiesFile> m_newFiles;
@@ -53,6 +56,7 @@ public class PropertiesTranslationStore implements IEditableTranslationStore {
     m_translations = new HashMap<>();
     m_files = new HashMap<>();
     m_newFiles = new HashSet<>();
+    m_encoding = svc.type().javaEnvironment().requireApi(IScoutApi.class).propertiesEncoding();
   }
 
   /**
@@ -193,12 +197,16 @@ public class PropertiesTranslationStore implements IEditableTranslationStore {
         .getParent();
 
     var fileName = getPropertiesFileName(service().filePrefix(), language);
-    ITranslationPropertiesFile newFile = new EditableTranslationFile(directory.resolve(fileName), language);
+    var newFile = new EditableTranslationFile(directory.resolve(fileName), encoding(), language);
     newFile.load(new NullProgress());
 
     setDirty(true);
     translationFiles().put(language, newFile);
     m_newFiles.add(newFile);
+  }
+
+  public Charset encoding() {
+    return m_encoding;
   }
 
   @Override

--- a/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/nls/properties/ReadOnlyTranslationFile.java
+++ b/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/nls/properties/ReadOnlyTranslationFile.java
@@ -10,6 +10,7 @@
 package org.eclipse.scout.sdk.core.s.nls.properties;
 
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.util.function.Supplier;
 
 import org.eclipse.scout.sdk.core.generator.properties.PropertiesGenerator;
@@ -26,12 +27,12 @@ public class ReadOnlyTranslationFile extends AbstractTranslationPropertiesFile {
 
   private final Object m_source;
 
-  public ReadOnlyTranslationFile(Supplier<InputStream> contentSupplier, Language language) {
-    this(contentSupplier, language, null);
+  public ReadOnlyTranslationFile(Supplier<InputStream> contentSupplier, Charset encoding, Language language) {
+    this(contentSupplier, encoding, language, null);
   }
 
-  public ReadOnlyTranslationFile(Supplier<InputStream> contentSupplier, Language language, Object source) {
-    super(language, contentSupplier);
+  public ReadOnlyTranslationFile(Supplier<InputStream> contentSupplier, Charset encoding, Language language, Object source) {
+    super(language, encoding, contentSupplier);
     m_source = source;
   }
 


### PR DESCRIPTION
For Scout >= 23.2 the RT reads the .properties files in UTF-8 encoding.

Therefore, for Scout >= 23.2 the following changes are applied:
- properties files are read and written using UTF-8 encoding.
- Non Latin1 characters do not use the unicode escaping anymore.

317392