### PR TITLE
ScoutJsModel: decide whether TS or JS by containing file

### DIFF
--- a/org.eclipse.scout.sdk.core.s.test/src/test/java/org/eclipse/scout/sdk/core/s/model/js/ScoutJsModelTest.java
+++ b/org.eclipse.scout.sdk.core.s.test/src/test/java/org/eclipse/scout/sdk/core/s/model/js/ScoutJsModelTest.java
@@ -11,9 +11,11 @@ package org.eclipse.scout.sdk.core.s.model.js;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.eclipse.scout.sdk.core.typescript.model.api.INodeElement;
 import org.eclipse.scout.sdk.core.typescript.model.api.INodeModule;
@@ -66,5 +68,25 @@ public class ScoutJsModelTest {
         .map(INodeElement::name)
         .toList();
     assertEquals(Arrays.asList(expectedDependencyNames), dependencyNames);
+  }
+
+  @Test
+  @ExtendWithNodeModules("ScoutJsModelTestWithEnums")
+  public void testScoutJsModelTestWithEnums(INodeModule scoutCore) {
+    var model = ScoutJsModels.create(scoutCore).orElseThrow();
+
+    var realEnumTS = model.findScoutEnums().withName("RealEnumTS").first().orElse(null);
+    assertNotNull(realEnumTS);
+    assertEquals(List.of("FIRST", "SECOND", "THIRD"), realEnumTS.constants());
+
+    var vertical = model.findScoutEnums().withName("Vertical").first().orElse(null);
+    assertNull(vertical);
+    var verticalEnum = model.findScoutEnums().withName("VerticalEnum").first().orElse(null);
+    assertNotNull(verticalEnum);
+    assertEquals(List.of("TOP", "BOTTOM"), verticalEnum.constants());
+
+    var horizontal = model.findScoutEnums().withName("Horizontal").first().orElse(null);
+    assertNotNull(horizontal);
+    assertEquals(List.of("LEFT", "RIGHT"), horizontal.constants());
   }
 }

--- a/org.eclipse.scout.sdk.core.s.test/src/test/resources/org/eclipse/scout/sdk/core/s/model/js/ScoutJsModelTestWithEnums.xml
+++ b/org.eclipse.scout.sdk.core.s.test/src/test/resources/org/eclipse/scout/sdk/core/s/model/js/ScoutJsModelTestWithEnums.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+  ~
+  ~ This program and the accompanying materials are made
+  ~ available under the terms of the Eclipse Public License 2.0
+  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+<module name="@eclipse-scout/core">
+  <export name="Widget">
+    <class name="Widget"></class>
+  </export>
+  <export name="EnumObject">
+    <class name="EnumObject"></class>
+  </export>
+  <export name="RealEnumTS">
+    <class name="RealEnumTS" file="RealEnumTS.ts" enum="true">
+      <field name="FIRST">
+        <constantValue>
+          <type>String</type>
+          <value>first</value>
+        </constantValue>
+      </field>
+      <field name="SECOND">
+        <constantValue>
+          <type>String</type>
+          <value>second</value>
+        </constantValue>
+      </field>
+      <field name="THIRD">
+        <constantValue>
+          <type>String</type>
+          <value>third</value>
+        </constantValue>
+      </field>
+    </class>
+  </export>
+  <export name="ClassTS">
+    <class name="ClassTS" file="ClassTS.ts">
+      <field name="Vertical">
+        <modifier name="STATIC"></modifier>
+        <constantValue>
+          <type>ObjectLiteral</type>
+          <value>
+            <objectLiteral>
+              <property name="TOP">
+                <constantValue>
+                  <type>String</type>
+                  <value>top</value>
+                </constantValue>
+              </property>
+              <property name="BOTTOM">
+                <constantValue>
+                  <type>String</type>
+                  <value>bottom</value>
+                </constantValue>
+              </property>
+            </objectLiteral>
+          </value>
+        </constantValue>
+      </field>
+    </class>
+  </export>
+  <export name="VerticalEnum">
+    <class name="VerticalEnum" file="VerticalEnum.ts">
+      <typeAlias>
+        <ref name="EnumObject" module="@eclipse-scout/core">
+          <typeArgument>
+            <typeOf>
+              <ref name="ClassTS" module="@eclipse-scout/core">
+                <field name="Vertical"></field>
+              </ref>
+            </typeOf>
+          </typeArgument>
+        </ref>
+      </typeAlias>
+    </class>
+  </export>
+  <export name="ClassJS">
+    <class name="ClassJS" file="ClassJS.js">
+      <field name="Horizontal">
+        <modifier name="STATIC"></modifier>
+        <constantValue>
+          <type>ObjectLiteral</type>
+          <value>
+            <objectLiteral>
+              <property name="LEFT">
+                <constantValue>
+                  <type>String</type>
+                  <value>left</value>
+                </constantValue>
+              </property>
+              <property name="RIGHT">
+                <constantValue>
+                  <type>String</type>
+                  <value>right</value>
+                </constantValue>
+              </property>
+            </objectLiteral>
+          </value>
+        </constantValue>
+      </field>
+    </class>
+  </export>
+</module>

--- a/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/model/js/AbstractScoutJsElementQuery.java
+++ b/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/model/js/AbstractScoutJsElementQuery.java
@@ -26,6 +26,7 @@ public abstract class AbstractScoutJsElementQuery<E extends IScoutJsElement, TYP
 
   private boolean m_includeDependencies;
   private boolean m_includeSelf = true;
+  private String m_name;
   private Set<IES6Class> m_declaringClasses;
 
   protected AbstractScoutJsElementQuery(ScoutJsModel model) {
@@ -57,6 +58,15 @@ public abstract class AbstractScoutJsElementQuery<E extends IScoutJsElement, TYP
   public TYPE withIncludeSelf(boolean includeSelf) {
     m_includeSelf = includeSelf;
     return thisInstance();
+  }
+
+  public TYPE withName(String name) {
+    m_name = name;
+    return thisInstance();
+  }
+
+  protected String name() {
+    return m_name;
   }
 
   public TYPE withDeclaringClasses(Stream<? extends IES6Class> declaringClasses) {
@@ -106,10 +116,22 @@ public abstract class AbstractScoutJsElementQuery<E extends IScoutJsElement, TYP
   protected Predicate<E> createFilter() {
     Predicate<E> result = null;
 
+    var name = name();
+    if (name != null) {
+      result = appendOrCreateFilter(result, e -> name().equals(e.name()));
+    }
+
     var declaringClassFilter = declaringClasses();
     if (declaringClassFilter != null) { // empty set means result is empty
-      result = e -> declaringClassFilter.contains(e.declaringClass());
+      result = appendOrCreateFilter(result, e -> declaringClassFilter.contains(e.declaringClass()));
     }
     return result;
+  }
+
+  protected static <E extends IScoutJsElement> Predicate<E> appendOrCreateFilter(Predicate<E> existing, Predicate<E> toAppend) {
+    if (existing == null) {
+      return toAppend;
+    }
+    return existing.and(toAppend);
   }
 }

--- a/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/model/js/objects/ScoutJsObjectQuery.java
+++ b/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/model/js/objects/ScoutJsObjectQuery.java
@@ -83,11 +83,4 @@ public class ScoutJsObjectQuery extends AbstractScoutJsElementQuery<IScoutJsObje
 
     return result;
   }
-
-  private static Predicate<IScoutJsObject> appendOrCreateFilter(Predicate<IScoutJsObject> existing, Predicate<IScoutJsObject> toAppend) {
-    if (existing == null) {
-      return toAppend;
-    }
-    return existing.and(toAppend);
-  }
 }

--- a/org.eclipse.scout.sdk.core.typescript/src/main/java/org/eclipse/scout/sdk/core/typescript/model/api/AbstractNodeElement.java
+++ b/org.eclipse.scout.sdk.core.typescript/src/main/java/org/eclipse/scout/sdk/core/typescript/model/api/AbstractNodeElement.java
@@ -16,18 +16,22 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Set;
 
+import org.eclipse.scout.sdk.core.typescript.IWebConstants;
 import org.eclipse.scout.sdk.core.typescript.builder.imports.ES6ImportCollector;
 import org.eclipse.scout.sdk.core.typescript.model.spi.NodeElementSpi;
 import org.eclipse.scout.sdk.core.util.Ensure;
 import org.eclipse.scout.sdk.core.util.FinalValue;
 import org.eclipse.scout.sdk.core.util.SourceRange;
+import org.eclipse.scout.sdk.core.util.Strings;
 
 public abstract class AbstractNodeElement<SPI extends NodeElementSpi> implements INodeElement {
   private final SPI m_spi;
+  private final FinalValue<Optional<String>> m_containingFileName;
   private final FinalValue<Optional<SourceRange>> m_source;
 
   protected AbstractNodeElement(SPI spi) {
     m_spi = Ensure.notNull(spi);
+    m_containingFileName = new FinalValue<>();
     m_source = new FinalValue<>();
   }
 
@@ -44,6 +48,16 @@ public abstract class AbstractNodeElement<SPI extends NodeElementSpi> implements
   @Override
   public Optional<Path> containingFile() {
     return spi().containingFile();
+  }
+
+  @Override
+  public Optional<String> containingFileName() {
+    return m_containingFileName.computeIfAbsentAndGet(() -> containingFile().map(Path::getFileName).map(Path::toString));
+  }
+
+  @Override
+  public boolean isTypeScript() {
+    return containingFileName().map(fileName -> Strings.endsWith(fileName, IWebConstants.TS_FILE_SUFFIX, false)).orElse(false);
   }
 
   @Override

--- a/org.eclipse.scout.sdk.core.typescript/src/main/java/org/eclipse/scout/sdk/core/typescript/model/api/INodeElement.java
+++ b/org.eclipse.scout.sdk.core.typescript/src/main/java/org/eclipse/scout/sdk/core/typescript/model/api/INodeElement.java
@@ -22,6 +22,10 @@ public interface INodeElement {
 
   Optional<Path> containingFile();
 
+  Optional<String> containingFileName();
+
+  boolean isTypeScript();
+
   NodeElementSpi spi();
 
   String name();

--- a/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/template/js/JsModelCompletionHelper.kt
+++ b/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/template/js/JsModelCompletionHelper.kt
@@ -319,7 +319,7 @@ object JsModelCompletionHelper {
         override fun icon(): Icon {
             val property = property()
             if (property.type().isChildModelSupported) {
-                if (property.scoutJsObject().scoutJsModel().supportsTypeScript()) {
+                if (property.scoutJsObject().declaringClass().isTypeScript) {
                     return JavaScriptPsiIcons.Classes.TypeScriptClass
                 }
                 return JavaScriptPsiIcons.Classes.JavaScriptClass
@@ -338,7 +338,7 @@ object JsModelCompletionHelper {
     data class JsObjectValueLookupElement(val propertyValue: ScoutJsObjectPropertyValue) : ScoutJsModelLookupElement {
         override fun property(): ScoutJsProperty = propertyValue.property()
         override fun icon(): Icon {
-            if (propertyValue.scoutJsObject.scoutJsModel().supportsTypeScript()) {
+            if (propertyValue.scoutJsObject.declaringClass().isTypeScript) {
                 return JavaScriptPsiIcons.Classes.TypeScriptClass
             }
             return JavaScriptPsiIcons.Classes.JavaScriptClass


### PR DESCRIPTION
Decide whether to parse TS or JS objects/enums by the containing file of the element and not by the main file of the containing module. There are modules containing valid JS and TS objects/enums. Parsing only the TS or only the JS objects/enums will result in an incomplete list of objects/enums.

356286