### PR TITLE
WidgetMap: support generics in objectTypes

### DIFF
--- a/org.eclipse.scout.sdk.core.s.test/src/test/java/org/eclipse/scout/sdk/core/s/widgetmap/WidgetMapCreateOperationTest.java
+++ b/org.eclipse.scout.sdk.core.s.test/src/test/java/org/eclipse/scout/sdk/core/s/widgetmap/WidgetMapCreateOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -108,6 +108,10 @@ public class WidgetMapCreateOperationTest {
     //            objectType: StringField
     //          },
     //          {
+    //            id: 'TypeField',
+    //            objectType: SmartField<number>
+    //          },
+    //          {
     //            id: 'SomeTableField',
     //            objectType: TableField,
     //            table: {
@@ -143,8 +147,8 @@ public class WidgetMapCreateOperationTest {
     //              objectType: FancyTable,
     //              columns: [
     //                {
-    //                  id: 'TextColumn',
-    //                  objectType: Column
+    //                  id: 'ObjectColumn',
+    //                  objectType: Column<object>
     //                }
     //              ]
     //            }
@@ -161,6 +165,7 @@ public class WidgetMapCreateOperationTest {
         "export type SomeFormWithTableFieldWidgetMap = {" +
             "'MainBox': GroupBox;" +
             "'TitleField': StringField;" +
+            "'TypeField': SmartField<number>;" +
             "'SomeTableField': TableField;" +
             "'SomeTable': SomeTable;" +
             "'FancyTableField': TableField;" +
@@ -182,14 +187,14 @@ public class WidgetMapCreateOperationTest {
             "declare columnMap: FancyTableFieldTableColumnMap;" +
             "}",
         "export type FancyTableFieldTableColumnMap = {" +
-            "'TextColumn': Column;" +
+            "'ObjectColumn': Column<object>;" +
             "} & FancyTableColumnMap;"
 
     ), operation.classSources());
 
     var imports = operation.importsForModel().stream().map(ES6ImportDescriptor::nameForSource).toList();
-    assertEquals(List.of("GroupBox", "StringField", "TableField", "SomeTable", "FancyTableFieldTable", "SomeTableWidgetMap", "Table", "SomeTableColumnMap", "Menu", "NumberColumn", "Column", "FancyTable", "FancyTableFieldTableColumnMap",
-        "FancyTableColumnMap"), imports);
+    assertEquals(List.of("GroupBox", "StringField", "SmartField", "TableField", "SomeTable", "FancyTableFieldTable", "SomeTableWidgetMap", "Table", "SomeTableColumnMap", "Menu", "NumberColumn", "Column", "FancyTable",
+        "FancyTableFieldTableColumnMap", "FancyTableColumnMap"), imports);
 
     var declarationSources = operation.declarationSources();
     assertEquals(1, declarationSources.size());

--- a/org.eclipse.scout.sdk.core.s.test/src/test/resources/org/eclipse/scout/sdk/core/s/widgetmap/SomeFormWithTableFieldModel.xml
+++ b/org.eclipse.scout.sdk.core.s.test/src/test/resources/org/eclipse/scout/sdk/core/s/widgetmap/SomeFormWithTableFieldModel.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!--
-  ~ Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+  ~ Copyright (c) 2010, 2024 BSI Business Systems Integration AG
   ~
   ~ This program and the accompanying materials are made
   ~ available under the terms of the Eclipse Public License 2.0
@@ -56,6 +56,29 @@
                                 <type>ES6Class</type>
                                 <value>
                                   <ref name="StringField" module="@eclipse-scout/core"></ref>
+                                </value>
+                              </constantValue>
+                            </property>
+                          </objectLiteral>
+                        </value>
+                      </constantValue>
+                      <constantValue>
+                        <type>ObjectLiteral</type>
+                        <value>
+                          <objectLiteral>
+                            <property name="id">
+                              <constantValue>
+                                <type>String</type>
+                                <value>TypeField</value>
+                              </constantValue>
+                            </property>
+                            <property name="objectType">
+                              <constantValue>
+                                <type>ES6Class</type>
+                                <value>
+                                  <ref name="SmartField" module="@eclipse-scout/core">
+                                    <typeArgument>number</typeArgument>
+                                  </ref>
                                 </value>
                               </constantValue>
                             </property>
@@ -252,14 +275,16 @@
                                                 <property name="id">
                                                   <constantValue>
                                                     <type>String</type>
-                                                    <value>TextColumn</value>
+                                                    <value>ObjectColumn</value>
                                                   </constantValue>
                                                 </property>
                                                 <property name="objectType">
                                                   <constantValue>
                                                     <type>ES6Class</type>
                                                     <value>
-                                                      <ref name="Column" module="@eclipse-scout/core"></ref>
+                                                      <ref name="Column" module="@eclipse-scout/core">
+                                                        <typeArgument>object</typeArgument>
+                                                      </ref>
                                                     </value>
                                                   </constantValue>
                                                 </property>
@@ -324,6 +349,13 @@
     </export>
     <export name="StringField">
       <class name="StringField">
+        <superClass>
+          <ref name="FormField" module="@eclipse-scout/core"></ref>
+        </superClass>
+      </class>
+    </export>
+    <export name="SmartField">
+      <class name="SmartField">
         <superClass>
           <ref name="FormField" module="@eclipse-scout/core"></ref>
         </superClass>

--- a/org.eclipse.scout.sdk.core.typescript.test/src/main/java/org/eclipse/scout/sdk/core/typescript/testing/spi/TestingNodeModulesProviderSpi.java
+++ b/org.eclipse.scout.sdk.core.typescript.test/src/main/java/org/eclipse/scout/sdk/core/typescript/testing/spi/TestingNodeModulesProviderSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -460,7 +460,10 @@ public class TestingNodeModulesProviderSpi implements NodeModulesProviderSpi {
       return createTypeOf(typeOfElement, moduleSpi);
     }
 
-    return null;
+    return Strings.notBlank(typeArgumentElement.getTextContent())
+        .map(TestingNodeElementFactorySpi::newDataType)
+        .map(IDataType::spi)
+        .orElse(null);
   }
 
   @SuppressWarnings("TypeMayBeWeakened")

--- a/org.eclipse.scout.sdk.core.typescript/src/main/java/org/eclipse/scout/sdk/core/typescript/builder/imports/ES6ImportValidator.java
+++ b/org.eclipse.scout.sdk.core.typescript/src/main/java/org/eclipse/scout/sdk/core/typescript/builder/imports/ES6ImportValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,6 +15,7 @@ import java.util.HashSet;
 
 import org.eclipse.scout.sdk.core.typescript.model.api.DataTypeNameEvaluator;
 import org.eclipse.scout.sdk.core.typescript.model.api.IDataType;
+import org.eclipse.scout.sdk.core.typescript.model.api.IES6Class;
 
 public class ES6ImportValidator implements IES6ImportValidator {
 
@@ -53,6 +54,9 @@ public class ES6ImportValidator implements IES6ImportValidator {
     }
     if (isBuiltInType(name)) {
       return name; // no import required
+    }
+    if (type instanceof IES6Class es6Class) {
+      type = es6Class.withoutTypeArguments();
     }
     var collector = importCollector();
     var usedNamesForSource = collector.usedNames();

--- a/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/model/typescript/IdeaNodeModule.kt
+++ b/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/model/typescript/IdeaNodeModule.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -205,7 +205,7 @@ class IdeaNodeModule(val moduleInventory: IdeaNodeModules, internal val nodeModu
 
     internal fun resolveExportTarget(element: PsiElement): List<JSElement> {
         var candidate: JSElement? = element as? JSElement
-        if (element.node.elementType == JSTokenTypes.EXPORT_KEYWORD) {
+        if (element.node?.elementType == JSTokenTypes.EXPORT_KEYWORD) {
             candidate = element.parent as? JSElement
         }
         if (candidate is JSAttributeList) {

--- a/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/model/typescript/util/DataTypeSpiUtils.kt
+++ b/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/model/typescript/util/DataTypeSpiUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
 package org.eclipse.scout.sdk.s2i.model.typescript.util
 
 import com.intellij.lang.javascript.psi.*
+import com.intellij.lang.javascript.psi.ecma6.JSTypeDeclaration
 import com.intellij.lang.javascript.psi.ecma6.TypeScriptAsExpression
 import com.intellij.lang.javascript.psi.ecma6.TypeScriptLiteralType
 import com.intellij.lang.javascript.psi.ecma6.TypeScriptTypeofType
@@ -104,11 +105,14 @@ object DataTypeSpiUtils {
 
         if (reference !is ES6ClassSpi) return reference
         if (sourceElement !is JSTypeArgumentsOwner) return reference
-        val typeArgumentClasses = sourceElement
-            .typeArguments
+        return resolveTypeArguments(reference, sourceElement.typeArguments, module)
+    }
+
+    fun resolveTypeArguments(es6Class: ES6ClassSpi, typeArguments: Array<out JSTypeDeclaration>, module: IdeaNodeModule): ES6ClassSpi? {
+        val typeArgumentClasses = typeArguments
             .mapNotNull { createDataType(it.jsType, module) }
-        if (typeArgumentClasses.isEmpty()) return reference
-        return module.nodeElementFactory().createClassWithTypeArgumentsDataType(reference, typeArgumentClasses)
+        if (typeArgumentClasses.isEmpty()) return es6Class
+        return module.nodeElementFactory().createClassWithTypeArgumentsDataType(es6Class, typeArgumentClasses)
     }
 
     private fun createDataType(objectLiteral: JSObjectLiteralExpression, module: IdeaNodeModule): DataTypeSpi? {

--- a/org.eclipse.scout.sdk.s2i/src/test/kotlin/org/eclipse/scout/sdk/s2i/model/typescript/IdeaJavaScriptClassTest.kt
+++ b/org.eclipse.scout.sdk.s2i/src/test/kotlin/org/eclipse/scout/sdk/s2i/model/typescript/IdeaJavaScriptClassTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,4 +14,6 @@ import org.eclipse.scout.sdk.s2i.model.AbstractES6ClassTest
 class IdeaJavaScriptClassTest : AbstractES6ClassTest("SomeClass", "javascript/moduleWithExternalImports") {
 
     override fun isOptionalPossible() = false
+
+    override fun isGenericsPossible() = false
 }

--- a/org.eclipse.scout.sdk.s2i/src/test/kotlin/org/eclipse/scout/sdk/s2i/model/typescript/IdeaObjectLiteralTest.kt
+++ b/org.eclipse.scout.sdk.s2i/src/test/kotlin/org/eclipse/scout/sdk/s2i/model/typescript/IdeaObjectLiteralTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.sdk.s2i.model.typescript
+
+import org.eclipse.scout.sdk.core.typescript.TypeScriptTypes
+import org.eclipse.scout.sdk.core.typescript.model.api.*
+import org.eclipse.scout.sdk.s2i.model.AbstractModelTest
+
+
+class IdeaObjectLiteralTest : AbstractModelTest("typescript/moduleWithExternalImports") {
+
+    fun testSampleModel() {
+        val arrow = myIdeaNodeModule.export("SampleModel").orElseThrow() as IFunction
+        val literal = arrow.resultingObjectLiteral().orElseThrow()
+
+        assertEquals("WildcardClass", literal.propertyAsES6Class("objectType").orElseThrow().name())
+
+        val fields = literal.propertyAs("fields", Array<IObjectLiteral>::class.java).orElseThrow()
+        assertEquals(4, fields.size)
+
+        val genericsNumber = fields[0]
+        assertEquals("GenericsNumber", genericsNumber.propertyAsString("id").orElseThrow())
+        val genericsNumberObjectType = genericsNumber.propertyAsES6Class("objectType").orElseThrow()
+        assertEquals("Generics", genericsNumberObjectType.name())
+        assertEquals(1, genericsNumberObjectType.typeArguments().count())
+        assertEquals(TypeScriptTypes._number, genericsNumberObjectType.typeArguments().findFirst().orElseThrow().name())
+
+        val genericsBoolean = fields[1]
+        assertEquals("GenericsBoolean", genericsBoolean.propertyAsString("id").orElseThrow())
+        val genericsBooleanObjectType = genericsBoolean.propertyAsES6Class("objectType").orElseThrow()
+        assertEquals("Generics", genericsBooleanObjectType.name())
+        assertEquals(1, genericsBooleanObjectType.typeArguments().count())
+        assertEquals(TypeScriptTypes._boolean, genericsBooleanObjectType.typeArguments().findFirst().orElseThrow().name())
+
+        val genericsString = fields[2]
+        assertEquals("GenericsString", genericsString.propertyAsString("id").orElseThrow())
+        val genericsStringObjectType = genericsString.propertyAsES6Class("objectType").orElseThrow()
+        assertEquals("Generics", genericsStringObjectType.name())
+        assertEquals(0, genericsStringObjectType.typeArguments().count())
+
+        val genericsNew = fields[3]
+        assertEquals("GenericsNew", genericsNew.propertyAsString("id").orElseThrow())
+        val genericsNewObjectType = genericsNew.propertyAsES6Class("objectType").orElseThrow()
+        assertEquals("Generics", genericsNewObjectType.name())
+        assertEquals(1, genericsNewObjectType.typeArguments().count())
+        val firstTypeArg = genericsNewObjectType.typeArguments().findFirst().orElseThrow()
+        assertTrue(firstTypeArg is IES6Class)
+        assertEquals("Generics", firstTypeArg.name())
+        val firstTypeArgNested = firstTypeArg.typeArguments().findFirst().orElseThrow()
+        assertTrue(firstTypeArgNested is IES6Class)
+        assertEquals("WildcardClass", firstTypeArgNested.name())
+    }
+}

--- a/org.eclipse.scout.sdk.s2i/src/test/resources/model/typescript/moduleWithExternalImports/src/SampleModel.ts
+++ b/org.eclipse.scout.sdk.s2i/src/test/resources/model/typescript/moduleWithExternalImports/src/SampleModel.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+// @ts-expect-error
+import {WildcardClass} from '@eclipse-scout/sdk-export-ts';
+import {Generics} from "./index";
+
+export default (): object => ({
+  objectType: WildcardClass,
+  fields: [
+    {
+      id: 'GenericsNumber',
+      objectType: Generics<number>
+    },
+    {
+      id: 'GenericsBoolean',
+      objectType: (Generics<boolean>)
+    },
+    {
+      id: 'GenericsString',
+      objectType: Generics
+    },
+    {
+      id: 'GenericsNew',
+      objectType: new Generics<Generics<WildcardClass>>
+    }
+  ]
+});
+
+// noinspection JSUnusedGlobalSymbols
+export type SampleWidgetMap = {
+  'GenericsNumber': Generics<number>;
+  'GenericsBoolean': Generics<boolean>;
+  'GenericsString': Generics;
+};

--- a/org.eclipse.scout.sdk.s2i/src/test/resources/model/typescript/moduleWithExternalImports/src/SomeClass.ts
+++ b/org.eclipse.scout.sdk.s2i/src/test/resources/model/typescript/moduleWithExternalImports/src/SomeClass.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -36,6 +36,15 @@ export class SomeClass<TArg0, TArg1 extends Promise<string> | string, TArg2 exte
 
   myRefDef: WildcardClassAlias;
   myRefInfer = new WildcardClassAlias();
+
+  myRefGenericsNumberDef: Generics<number>;
+  myRefGenericsNumberInfer = new Generics<number>();
+
+  myRefGenericsBooleanDef: (Generics<boolean>);
+  myRefGenericsBooleanInfer = (new Generics<boolean>());
+
+  myRefGenericsStringDef: Generics;
+  myRefGenericsStringInfer = new Generics();
 
   myStaticStringRefInfer = SomeClass.myStaticStringDef;
   myEnumRefInfer = SomeClass.myEnumInfer.b;
@@ -80,3 +89,8 @@ type BC = {
   b: number;
   c: number;
 };
+
+// noinspection JSUnusedGlobalSymbols
+export class Generics<TType = string> {
+  prop?: TType;
+}

--- a/org.eclipse.scout.sdk.s2i/src/test/resources/model/typescript/moduleWithExternalImports/src/SomeInterface.ts
+++ b/org.eclipse.scout.sdk.s2i/src/test/resources/model/typescript/moduleWithExternalImports/src/SomeInterface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
 
 // @ts-expect-error
 import {WildcardClass as WildcardClassAlias, WildcardType} from '@eclipse-scout/sdk-export-ts';
+import {Generics} from './index';
 
 // noinspection JSUnusedGlobalSymbols
 export interface SomeInterface {
@@ -21,6 +22,9 @@ export interface SomeInterface {
   myObjectDef: object;
   myAnyDef?: any;
   myRefDef: WildcardClassAlias;
+  myRefGenericsNumberDef: Generics<number>;
+  myRefGenericsBooleanDef: (Generics<boolean>);
+  myRefGenericsStringDef: Generics;
   myStringArrayDef?: string[][];
   myNumberArrayDef: number[];
   myStringNumberUnionDef: string | number;

--- a/org.eclipse.scout.sdk.s2i/src/test/resources/model/typescript/moduleWithExternalImports/src/SomeType.ts
+++ b/org.eclipse.scout.sdk.s2i/src/test/resources/model/typescript/moduleWithExternalImports/src/SomeType.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
 
 // @ts-expect-error
 import {WildcardClass as WildcardClassAlias} from '@eclipse-scout/sdk-export-ts';
+import {Generics} from "./index";
 
 // noinspection JSUnusedGlobalSymbols
 export type SomeType = {
@@ -21,6 +22,9 @@ export type SomeType = {
   myObjectDef: object;
   myAnyDef?: any;
   myRefDef: WildcardClassAlias;
+  myRefGenericsNumberDef: Generics<number>;
+  myRefGenericsBooleanDef: (Generics<boolean>);
+  myRefGenericsStringDef: Generics;
   myStringArrayDef?: string[][];
   myNumberArrayDef: number[];
   myStringNumberUnionDef: string | number;

--- a/org.eclipse.scout.sdk.s2i/src/test/resources/model/typescript/moduleWithExternalImports/src/index.ts
+++ b/org.eclipse.scout.sdk.s2i/src/test/resources/model/typescript/moduleWithExternalImports/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,8 @@
  */
 
 export * from './ClassWithSupers';
+// noinspection JSUnusedGlobalSymbols
+export {default as SampleModel} from './SampleModel';
 export * from './SomeClass';
 export * from './SomeInterface';
 export * from './SomeType';


### PR DESCRIPTION
Parse typeArguments while converting an IdeaConstantValue to an ES6Class. In addition, unwrap JSParenthesizedExpression and (for IJ >= 2023.2) TypeScriptExpressionWithTypeArguments. Fix NPE while resolving the export target.

377491