### PR TITLE
Limit the Scout version selection for creating new projects

### DIFF
--- a/org.eclipse.scout.sdk.core.java.test/src/test/java/org/eclipse/scout/sdk/core/java/apidef/ApiVersionTest.java
+++ b/org.eclipse.scout.sdk.core.java.test/src/test/java/org/eclipse/scout/sdk/core/java/apidef/ApiVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -50,6 +50,14 @@ public class ApiVersionTest {
     assertArrayEquals(segments, v.segments());
     assertNotSame(segments, v.segments());
     assertEquals(12, v.major());
+
+    assertArrayEquals(new int[0], v.segments(-1));
+    assertArrayEquals(new int[0], v.segments(0));
+    assertArrayEquals(new int[]{12}, v.segments(1));
+    assertArrayEquals(segments, v.segments(2));
+    assertArrayEquals(segments, v.segments(3));
+    assertArrayEquals(segments, v.segments(4));
+
   }
 
   @Test

--- a/org.eclipse.scout.sdk.core.java/src/main/java/org/eclipse/scout/sdk/core/java/apidef/ApiVersion.java
+++ b/org.eclipse.scout.sdk.core.java/src/main/java/org/eclipse/scout/sdk/core/java/apidef/ApiVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -57,9 +57,9 @@ public class ApiVersion implements Comparable<ApiVersion> {
    * Parses the value of an {@link MaxApiLevel} annotation on the given class.
    *
    * @param clazz
-   *          The class whose {@link MaxApiLevel} annotation should be parsed.
+   *     The class whose {@link MaxApiLevel} annotation should be parsed.
    * @return An {@link Optional} with the {@link ApiVersion} of the given class or an empty {@link Optional} if the
-   *         given class is {@code null} or the annotation does not exist.
+   * given class is {@code null} or the annotation does not exist.
    * @see #requireMaxApiLevelOf(Class)
    */
   public static Optional<ApiVersion> maxApiLevelOf(Class<?> clazz) {
@@ -74,10 +74,10 @@ public class ApiVersion implements Comparable<ApiVersion> {
    * not have an {@link MaxApiLevel} annotation.
    *
    * @param clazz
-   *          The class whose {@link MaxApiLevel} annotation should be parsed.
+   *     The class whose {@link MaxApiLevel} annotation should be parsed.
    * @return The {@link ApiVersion} value of the annotation.
    * @throws IllegalArgumentException
-   *           if the clazz is {@code null} or the clazz does not have the {@link MaxApiLevel} annotation.
+   *     if the clazz is {@code null} or the clazz does not have the {@link MaxApiLevel} annotation.
    * @see #maxApiLevelOf(Class)
    */
   public static ApiVersion requireMaxApiLevelOf(Class<?> clazz) {
@@ -89,7 +89,7 @@ public class ApiVersion implements Comparable<ApiVersion> {
    * Parses the given {@link CharSequence} into an {@link ApiVersion}.
    *
    * @param version
-   *          The {@link CharSequence} to parse. It must fulfill {@link #VERSION_PATTERN} to be successfully parsed.
+   *     The {@link CharSequence} to parse. It must fulfill {@link #VERSION_PATTERN} to be successfully parsed.
    * @return The {@link ApiVersion} or an empty {@link Optional} if the given {@link CharSequence} cannot be parsed.
    */
   public static Optional<ApiVersion> parse(CharSequence version) {
@@ -113,8 +113,8 @@ public class ApiVersion implements Comparable<ApiVersion> {
 
   /**
    * @return The suffix {@link String} or {@code null} if this {@link ApiVersion} has no suffix. The suffix is the whole
-   *         part after the maximal three number sections including the delimiter (e.g. {@code "-SNAPSHOT"} or
-   *         {@code ".SUFFIX"}).
+   * part after the maximal three number sections including the delimiter (e.g. {@code "-SNAPSHOT"} or
+   * {@code ".SUFFIX"}).
    */
   public String suffix() {
     return m_suffix;
@@ -124,7 +124,16 @@ public class ApiVersion implements Comparable<ApiVersion> {
    * @return A copy of all number segments of the version. Never returns {@code null}.
    */
   public int[] segments() {
-    return Arrays.copyOf(m_segments, m_segments.length);
+    return segments(m_segments.length);
+  }
+
+  /**
+   * @param n
+   *     The number of segments to copy. Must be in the range {@code [0, segments.length]}.
+   * @return A copy of the first n segments of the version. Never returns {@code null}.
+   */
+  public int[] segments(int n) {
+    return Arrays.copyOf(m_segments, Math.max(0, Math.min(n, m_segments.length)));
   }
 
   /**
@@ -176,9 +185,9 @@ public class ApiVersion implements Comparable<ApiVersion> {
   /**
    * Compares all segments which exist in this {@link ApiVersion} and the given one. Therefore, the compare aborts on
    * the first segments that has a different value or after the last segment that exists for both instances.
-   * 
+   *
    * @param o
-   *          The {@link ApiVersion} to compare against.
+   *     The {@link ApiVersion} to compare against.
    * @return The difference of the first segments that exists in both instances and have a different value.
    */
   public int compareCommonSegmentsTo(ApiVersion o) {

--- a/org.eclipse.scout.sdk.core.s.test/src/test/java/org/eclipse/scout/sdk/core/s/model/js/ScoutJsCoreConstantsTest.java
+++ b/org.eclipse.scout.sdk.core.s.test/src/test/java/org/eclipse/scout/sdk/core/s/model/js/ScoutJsCoreConstantsTest.java
@@ -246,8 +246,8 @@ public class ScoutJsCoreConstantsTest {
   }
 
   private static String getNewestModuleUrl(String name) throws IOException {
-    var versionSuffix = getCurrentVersionSuffix();
-    if (versionSuffix == null) {
+    var versionPrefix = getCurrentVersionPrefix();
+    if (versionPrefix == null) {
       SdkLog.warning("{} skipped for current Scout version '{}'.", ScoutJsCoreConstantsTest.class.getSimpleName(), CoreScoutTestingUtils.currentScoutVersion());
       return null;
     }
@@ -256,20 +256,20 @@ public class ScoutJsCoreConstantsTest {
       var obj = parser.readObject();
       var newest = obj.getJsonObject("versions")
           .entrySet().stream()
-          .filter(entry -> entry.getKey().startsWith(versionSuffix))
+          .filter(entry -> entry.getKey().startsWith(versionPrefix))
           .collect(Collectors.toMap(entry -> ApiVersion.parse(entry.getKey()).orElseThrow(), entry -> (JsonObject) entry.getValue(), Ensure::failOnDuplicates, TreeMap::new))
           .lastEntry();
       if (newest == null) {
-        SdkLog.warning("Could not find any version for Node package '{}' starting with '{}' on '{}'.", name, versionSuffix, npmJsUrl);
+        SdkLog.warning("Could not find any version for Node package '{}' starting with '{}' on '{}'.", name, versionPrefix, npmJsUrl);
         return null; // no version found
       }
       return newest.getValue().getJsonObject("dist").getString("tarball");
     }
   }
 
-  private static String getCurrentVersionSuffix() {
+  private static String getCurrentVersionPrefix() {
     var version = CoreScoutTestingUtils.currentScoutVersion(); // e.g. 24.1-SNAPSHOT
-    var segments = ApiVersion.parse(version).orElseThrow().segments();
+    var segments = ApiVersion.parse(version).orElseThrow().segments(2);
     if (segments[0] <= 22) {
       return null; // this test only supports versions >= 23.1 (TypeScript)
     }

--- a/org.eclipse.scout.sdk.core.s.test/src/test/java/org/eclipse/scout/sdk/core/s/project/ScoutProjectNewHelperTest.java
+++ b/org.eclipse.scout.sdk.core.s.test/src/test/java/org/eclipse/scout/sdk/core/s/project/ScoutProjectNewHelperTest.java
@@ -11,11 +11,14 @@ package org.eclipse.scout.sdk.core.s.project;
 
 import static org.eclipse.scout.sdk.core.s.project.ScoutProjectNewHelper.getSupportedArchetypeVersions;
 import static org.eclipse.scout.sdk.core.s.project.ScoutProjectNewHelper.getSupportedJavaVersions;
+import static org.eclipse.scout.sdk.core.s.project.ScoutProjectNewHelper.limitToLtsOrNewest;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.eclipse.scout.sdk.core.java.apidef.ApiVersion;
 import org.eclipse.scout.sdk.core.s.java.apidef.ScoutApi;
@@ -52,10 +55,28 @@ public class ScoutProjectNewHelperTest {
     assertFalse(javaScriptPreview.isEmpty());
     assertTrue(javaRelease.size() <= javaPreview.size());
     assertTrue(javaScriptRelease.size() <= javaScriptPreview.size());
-    assertTrue(javaRelease.stream().anyMatch(v -> v.startsWith("22.")));
     assertTrue(javaRelease.stream().anyMatch(v -> v.startsWith("23.")));
     assertTrue(javaRelease.stream().anyMatch(v -> v.startsWith("24.")));
     assertTrue(javaPreview.stream().anyMatch(v -> v.startsWith("25.")));
     assertTrue(javaScriptPreview.stream().anyMatch(v -> v.startsWith("25.")));
+  }
+
+  @Test
+  public void testLimitToLtsOrNewest() {
+    assertEquals(List.of(ApiVersion.parse("25.2.0-beta.1").orElseThrow(),
+        ApiVersion.parse("25.2.0-beta.0").orElseThrow(),  // X.2 are LTS and therefore always preserved
+        ApiVersion.parse("25.1.15").orElseThrow(), // newest stable is always preserved (even if X.1)
+        ApiVersion.parse("25.1.12").orElseThrow(), // newest stable is always preserved (even if X.1)
+        ApiVersion.parse("24.2.16").orElseThrow(), // X.2 are LTS and therefore always preserved
+        ApiVersion.parse("24.2.2").orElseThrow()  // X.2 are LTS and therefore always preserved
+    ), limitToLtsOrNewest(List.of(ApiVersion.parse("25.2.0-beta.1").orElseThrow(),
+        ApiVersion.parse("25.2.0-beta.0").orElseThrow(),
+        ApiVersion.parse("25.1.15").orElseThrow(),
+        ApiVersion.parse("25.1.12").orElseThrow(),
+        ApiVersion.parse("24.2.16").orElseThrow(),
+        ApiVersion.parse("24.2.2").orElseThrow(),
+        ApiVersion.parse("24.1.4").orElseThrow(),
+        ApiVersion.parse("24.1.0-beta.1").orElseThrow()
+    )).toList());
   }
 }

--- a/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/project/ScoutProjectNewHelper.java
+++ b/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/project/ScoutProjectNewHelper.java
@@ -9,24 +9,24 @@
  */
 package org.eclipse.scout.sdk.core.s.project;
 
-import static java.util.Comparator.naturalOrder;
+import static java.util.Collections.emptyList;
 import static java.util.Comparator.reverseOrder;
-import static java.util.stream.Collectors.toList;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import javax.xml.transform.TransformerException;
 
 import org.eclipse.scout.sdk.core.java.JavaTypes;
 import org.eclipse.scout.sdk.core.java.apidef.ApiVersion;
-import org.eclipse.scout.sdk.core.java.apidef.IApiSpecification;
 import org.eclipse.scout.sdk.core.log.SdkLog;
 import org.eclipse.scout.sdk.core.s.environment.IEnvironment;
 import org.eclipse.scout.sdk.core.s.environment.IProgress;
@@ -254,7 +254,7 @@ public final class ScoutProjectNewHelper {
   }
 
   /**
-   * Gets all Scout versions available on Maven central which are supported by this SDK.
+   * Gets all Scout versions >= 23 (older projects should no longer be created) available on Maven central.
    *
    * @param useJavaClient
    *     {@code true} if the versions for the archetype with the Java UI should be returned, {@code false} for the
@@ -266,18 +266,45 @@ public final class ScoutProjectNewHelper {
    *     if there is an error reading the versions from Maven central
    */
   public static List<String> getSupportedArchetypeVersions(boolean useJavaClient, boolean includePreviewVersions) throws IOException {
+    // versions older than 23 should no longer be created as the support for them is reduced. For new project more up-to-date version should be chosen.
+    // Furthermore, e.g. Eclipse can no longer run such old versions.
+    // Can be removed as soon as support for Scout versions < 23 is dropped in the ScoutApi.
+    var min = ApiVersion.parse("23.0.0").orElseThrow();
     var artifactId = useJavaClient ? SCOUT_ARCHETYPES_HELLOWORLD_ARTIFACT_ID : SCOUT_ARCHETYPES_HELLOJS_ARTIFACT_ID;
-    var min = ScoutApi.allKnown()
-        .map(IApiSpecification::maxLevel)
-        .min(naturalOrder())
-        .orElseThrow();
-    return MavenArtifactVersions.allOnCentral(SCOUT_ARCHETYPES_GROUP_ID, artifactId)
+    var availableVersions = MavenArtifactVersions.allOnCentral(SCOUT_ARCHETYPES_GROUP_ID, artifactId)
         .map(ApiVersion::parse)
         .flatMap(Optional::stream)
         .filter(v -> v.compareCommonSegmentsTo(min) >= 0) // only supported versions
-        .filter(v -> includePreviewVersions || Strings.isEmpty(v.suffix())) // include preview versions?
         .sorted(reverseOrder()) // newest first
+        .toList();
+    if (availableVersions.isEmpty()) {
+      return emptyList();
+    }
+    return limitToLtsOrNewest(availableVersions) // only newest X.1 release
+        .filter(v -> includePreviewVersions || Strings.isEmpty(v.suffix())) // include preview versions?
         .map(ApiVersion::asString)
-        .collect(toList());
+        .toList();
+  }
+
+  static Stream<ApiVersion> limitToLtsOrNewest(Collection<ApiVersion> availableVersions) {
+    // The X.1 versions are only still supported, if they are the newest version available.
+    // As soon as the next X.2 release is available, the X.1 release is no longer maintained.
+    // Therefore, creating new projects on X.1 releases should only be allowed if it is the newest.
+    var newestStableMajorMinor = availableVersions.stream()
+        .filter(version -> Strings.isEmpty(version.suffix())) // stable only
+        .findFirst() // first must be newest
+        .orElseThrow()
+        .segments(2);
+    return availableVersions.stream()
+        .filter(v -> isLtsOrNewest(v, newestStableMajorMinor));
+  }
+
+  static boolean isLtsOrNewest(ApiVersion version, int[] newestStableMajorMinor) {
+    var candidate = version.segments();
+    if (candidate.length < 2 || newestStableMajorMinor.length < 2) {
+      return true; // accept versions with only one number (should not exist)
+    }
+    return candidate[1] != 1 // it's an X.2 release (LTS) -> always accept
+        || (candidate[0] == newestStableMajorMinor[0] && candidate[1] == newestStableMajorMinor[1]); // it's the newest release (which might be an X.1) -> always accept
   }
 }


### PR DESCRIPTION
The supported versions have the following new constraints:
1. Version must be >= 23.0
2. Version must be LTS or the newest stable release