### PR TITLE
Improve ScoutProjectNewHelper

### DIFF
--- a/org.eclipse.scout.sdk.core.s.test/src/test/java/org/eclipse/scout/sdk/core/s/project/ScoutProjectNewHelperTest.java
+++ b/org.eclipse.scout.sdk.core.s.test/src/test/java/org/eclipse/scout/sdk/core/s/project/ScoutProjectNewHelperTest.java
@@ -62,6 +62,7 @@ public class ScoutProjectNewHelperTest {
 
   @Test
   public void testLimitToLtsOrNewest() {
+    // X.1 is latest stable -> X.2-beta need to be preserved as well
     assertEquals(List.of(ApiVersion.parse("25.2.0-beta.1").orElseThrow(),
         ApiVersion.parse("25.2.0-beta.0").orElseThrow(),  // X.2 are LTS and therefore always preserved
         ApiVersion.parse("25.1.15").orElseThrow(), // newest stable is always preserved (even if X.1)
@@ -72,6 +73,25 @@ public class ScoutProjectNewHelperTest {
         ApiVersion.parse("25.2.0-beta.0").orElseThrow(),
         ApiVersion.parse("25.1.15").orElseThrow(),
         ApiVersion.parse("25.1.12").orElseThrow(),
+        ApiVersion.parse("24.2.16").orElseThrow(),
+        ApiVersion.parse("24.2.2").orElseThrow(),
+        ApiVersion.parse("24.1.4").orElseThrow(),
+        ApiVersion.parse("24.1.0-beta.1").orElseThrow()
+    )).toList());
+
+    // X.2 is latest stable -> X+1.1-beta need to be preserved as well
+    assertEquals(List.of(ApiVersion.parse("26.1.0-beta.1").orElseThrow(), // newest is always preserved (even if X.1)
+        ApiVersion.parse("26.1.0-beta.0").orElseThrow(),  // newest is always preserved (even if X.1)
+        ApiVersion.parse("25.2.15").orElseThrow(), // X.2 are LTS and therefore always preserved
+        ApiVersion.parse("25.2.12").orElseThrow(), // X.2 are LTS and therefore always preserved
+        ApiVersion.parse("25.2.0-beta.0").orElseThrow(), // X.2 are LTS and therefore always preserved
+        ApiVersion.parse("24.2.16").orElseThrow(), // X.2 are LTS and therefore always preserved
+        ApiVersion.parse("24.2.2").orElseThrow()  // X.2 are LTS and therefore always preserved
+    ), limitToLtsOrNewest(List.of(ApiVersion.parse("26.1.0-beta.1").orElseThrow(),
+        ApiVersion.parse("26.1.0-beta.0").orElseThrow(),
+        ApiVersion.parse("25.2.15").orElseThrow(),
+        ApiVersion.parse("25.2.12").orElseThrow(),
+        ApiVersion.parse("25.2.0-beta.0").orElseThrow(),
         ApiVersion.parse("24.2.16").orElseThrow(),
         ApiVersion.parse("24.2.2").orElseThrow(),
         ApiVersion.parse("24.1.4").orElseThrow(),

--- a/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/project/ScoutProjectNewHelper.java
+++ b/org.eclipse.scout.sdk.core.s/src/main/java/org/eclipse/scout/sdk/core/s/project/ScoutProjectNewHelper.java
@@ -305,6 +305,7 @@ public final class ScoutProjectNewHelper {
       return true; // accept versions with only one number (should not exist)
     }
     return candidate[1] != 1 // it's an X.2 release (LTS) -> always accept
-        || (candidate[0] == newestStableMajorMinor[0] && candidate[1] == newestStableMajorMinor[1]); // it's the newest release (which might be an X.1) -> always accept
+        || (candidate[0] == newestStableMajorMinor[0] && candidate[1] == newestStableMajorMinor[1]) // it's the newest release (which might be an X.1) -> always accept
+        || candidate[0] >= newestStableMajorMinor[0]; // it's newer than the newest release (e.g. X.2 is the newest stable, than X+1.1-beta.0 needs to be accepted)
   }
 }


### PR DESCRIPTION
If the latest stable version is an X.2-version, preview versions of newer releases must not be filtered out (e.g. X+1.1-beta.1). Therefore, add a check if the major-version of a candidate is greater than the one of the newest stable release to ScoutProjectNewHelper.isLtsOrNewest.