### PR TITLE
Show JsDoc for Scout JS models in Quick Documentation

### DIFF
--- a/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/template/js/JsModelCompletionHelper.kt
+++ b/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/template/js/JsModelCompletionHelper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -120,11 +120,10 @@ object JsModelCompletionHelper {
     }
 
     private fun createLookupElement(modelElement: ScoutJsModelLookupElement, completionInfo: JsModelCompletionInfo): LookupElementBuilder {
-        val name = modelElement.name()
         val presentableName = modelElement.presentableName()
         val lookupString = createLookupString(modelElement, completionInfo)
 
-        var result = LookupElementBuilder.create(name, lookupString)
+        var result = LookupElementBuilder.create(modelElement, lookupString)
             .withLookupString(presentableName)
             .withCaseSensitivity(true)
             .withPresentableText(presentableName)

--- a/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/template/js/JsModelCompletionInfo.kt
+++ b/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/template/js/JsModelCompletionInfo.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -55,7 +55,7 @@ data class JsModelCompletionInfo(
             .orElse(null)
     }
 
-    private fun declaringScoutObjectByObjectType() = m_objectTypeScoutObject.computeIfAbsentAndGet {
+    fun declaringScoutObjectByObjectType() = m_objectTypeScoutObject.computeIfAbsentAndGet {
         val referencedClass = findReferencedClass() ?: return@computeIfAbsentAndGet null
         val objectTypeModel = objectTypeModel() ?: return@computeIfAbsentAndGet null
         objectTypeModel

--- a/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/template/js/JsModelPropertyDocumentationProvider.kt
+++ b/org.eclipse.scout.sdk.s2i/src/main/kotlin/org/eclipse/scout/sdk/s2i/template/js/JsModelPropertyDocumentationProvider.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.scout.sdk.s2i.template.js
+
+import com.intellij.lang.documentation.AbstractDocumentationProvider
+import com.intellij.lang.javascript.psi.JSField
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
+import org.eclipse.scout.sdk.core.s.model.js.prop.ScoutJsProperty
+import org.eclipse.scout.sdk.s2i.model.typescript.IdeaJavaScriptField
+
+class JsModelPropertyDocumentationProvider : AbstractDocumentationProvider() {
+
+    override fun getCustomDocumentationElement(editor: Editor, file: PsiFile, contextElement: PsiElement?, targetOffset: Int): PsiElement? {
+        val element = contextElement ?: return null
+        val info = JsModelCompletionHelper.getPropertyValueInfo(element, "") ?: return contextElement
+        val scoutObject = info.declaringScoutObjectByObjectType() ?: return contextElement
+        val property = scoutObject
+            .findProperties()
+            .withSupers(true)
+            .withName(info.propertyName)
+            .first().orElse(null) ?: return contextElement
+        return propertyToPsi(property) ?: contextElement
+    }
+
+    override fun getDocumentationElementForLookupItem(psiManager: PsiManager, lookupObject: Any?, elementUnderCursor: PsiElement?): PsiElement? {
+        val jsNameLookupElement = lookupObject as? JsModelCompletionHelper.JsNameLookupElement ?: return null
+        return propertyToPsi(jsNameLookupElement.scoutJsProperty)
+    }
+
+    private fun propertyToPsi(property: ScoutJsProperty): JSField? {
+        val spi = property.field().spi() as? IdeaJavaScriptField ?: return null
+        return spi.javaScriptField
+    }
+}

--- a/org.eclipse.scout.sdk.s2i/src/main/resources/META-INF/withJavaScript.xml
+++ b/org.eclipse.scout.sdk.s2i/src/main/resources/META-INF/withJavaScript.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+  ~ Copyright (c) 2010, 2026 BSI Business Systems Integration AG
   ~
   ~ This program and the accompanying materials are made
   ~ available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,8 @@
     <completion.contributor language="TypeScript" implementationClass="org.eclipse.scout.sdk.s2i.nls.completion.NlsCompletionContributorForJs" id="scoutNlsCompletionTs" order="first"/>
     <lang.documentationProvider language="JavaScript" implementationClass="org.eclipse.scout.sdk.s2i.nls.doc.NlsDocumentationProviderForJs" id="scoutNlsKeyDocumentationJs" order="first"/>
     <lang.documentationProvider language="TypeScript" implementationClass="org.eclipse.scout.sdk.s2i.nls.doc.NlsDocumentationProviderForJs" id="scoutNlsKeyDocumentationTs" order="first"/>
+    <lang.documentationProvider language="JavaScript" implementationClass="org.eclipse.scout.sdk.s2i.template.js.JsModelPropertyDocumentationProvider" id="scoutJsModelPropertyDocumentationJs" order="first"/>
+    <lang.documentationProvider language="TypeScript" implementationClass="org.eclipse.scout.sdk.s2i.template.js.JsModelPropertyDocumentationProvider" id="scoutJsModelPropertyDocumentationTs" order="first"/>
     <completion.contributor language="JavaScript" implementationClass="org.eclipse.scout.sdk.s2i.template.js.JsModelNameCompletionContributor" id="scoutModelNameCompletionJs" order="first"/>
     <completion.contributor language="JavaScript" implementationClass="org.eclipse.scout.sdk.s2i.template.js.JsModelValueCompletionContributor" id="scoutModelValueCompletionJs" order="first"/>
   </extensions>


### PR DESCRIPTION
Supports Ctrl+q on a property or a property completion entry.

421140